### PR TITLE
Adds capability to update previously installed plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
   # Run the role/playbook with ansible-playbook.
   - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo"
 
+  # Run the role/playbook with ansible-playbook including optional parameters.
+  - "ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo --extra-vars jenkins_update_plugins=True"
+
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
     ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
       - sonar
       - ssh
 
-Jenkins plugins to be installed automatically during provisioning. You can always install more plugins via the Jenkins UI at a later time, but this is helpful in getting things up and running more quickly.
+Jenkins plugins to be installed automatically during provisioning. You can always install more plugins via the Jenkins UI at a later time, but this is helpful in getting things up and running more quickly. New plugins are automatically installed in the latest version.
+
+    jenkins_update_plugins: False
+
+By default, no previously installed plugins will be updated. If you however want all previously installed plugins to be updated to their latest version, set the `jenkins_update_plugins` variable to `True`. You can also turn on plugin updating ad-hoc for an `ansible-playbook` call on the command line, by specifying `--extra-vars jenkins_update_plugins=True`.
 
     # For RedHat/CentOS (role default):
     jenkins_repo_url: http://pkg.jenkins-ci.org/redhat/jenkins.repo

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ jenkins_plugins:
   - git
   - sonar
   - ssh
+jenkins_update_plugins: False

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -27,3 +27,20 @@
     creates=/var/lib/jenkins/plugins/{{ item }}.jpi
   with_items: jenkins_plugins
   notify: restart jenkins
+
+- name: Check for updates.
+  shell: >
+    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:8080/ list-plugins
+  changed_when: false
+  when: jenkins_update_plugins
+  register: updates
+
+- name: Update all Jenkins plugins.
+  # The plugin name is the first white space-separated column in a list-plugins stdout_line, the plugin name does not contain spaces
+  command: >
+    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:8080/ install-plugin {{ item.split(' ')[0] }}
+  with_items:
+     - "{{ updates.stdout_lines }}"
+  # If an update is available, Jenkins' list-plugins command returns the update version number in parenthesis at the end of the line
+  when: jenkins_update_plugins and item | last == ")"
+  notify: restart jenkins


### PR DESCRIPTION
Hi. Would you be interested to add this functionality to update previously existing plugins in your jenkins role?
The updating is turned off by default, since you will only want to do this if you know won't break anything. I use this for staging jenkins updates.

Regards,
Alexander