### PR TITLE
Update wait to use curl instead of wait_for since Jenkins is Java

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,10 +25,11 @@
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
-  wait_for:
-    host: "{{ jenkins_hostname }}"
-    port: 8080
-    timeout: 300
+  shell: curl --head --silent http://{{ jenkins_hostname }}:8080/cli/
+  register: result
+  until: result.stdout.find("200 OK") != -1
+  retries: 18
+  delay: 5
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
   get_url:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,9 @@
   shell: curl --head --silent http://{{ jenkins_hostname }}:8080/cli/
   register: result
   until: result.stdout.find("200 OK") != -1
-  retries: 18
+  retries: 12
   delay: 5
+  changed_when: false
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
   get_url:


### PR DESCRIPTION
### Reviewers

- [ ] @geerlingguy 

cc: 
### High level summary

The ansible wait_for module checks to ensure a TCP connection can be made. This results in this role failing to complete on first iteration with the following error:

```
failed: [jenkinstest] => {"attempts": 5, "dest": "/opt/jenkins-cli.jar", "failed": true, "response": "HTTP Error 503: Service Unavailable", "state": "absent", "status_code": 503, "url": "http://localhost:8080/jnlpJars/jenkins-cli.jar"}
msg: Task failed as maximum retries was encountered
```

### Approach

Switch to checking the response code of Jenkins.

This addresses GitHub Issue: https://github.com/geerlingguy/ansible-role-jenkins/issues/12