### PR TITLE
Enable the duration of the retries to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Jenkins plugins to be installed automatically during provisioning. You can alway
 
 The amount of time to wait between connection attempts to the Jenkins web interface to verify it has started.
 
-    jenkins_connection_retries: 12
+    jenkins_connection_retries: 60
 
 The number of times to attempt to connect to the Jenkins web interface looking for a 200 response before giving up.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 
 Jenkins plugins to be installed automatically during provisioning. You can always install more plugins via the Jenkins UI at a later time, but this is helpful in getting things up and running more quickly.
 
+    jenkins_connection_delay: 5
+
+The amount of time to wait between connection attempts to the Jenkins web interface to verify it has started.
+
+    jenkins_connection_retries: 12
+
+The number of times to attempt to connect to the Jenkins web interface looking for a 200 response before giving up.
+
     # For RedHat/CentOS (role default):
     jenkins_repo_url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
     jenkins_repo_key_url: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 jenkins_connection_delay: 5
-jenkins_connection_retries: 12
+jenkins_connection_retries: 60
 jenkins_hostname: localhost
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+jenkins_connection_delay: 5
+jenkins_connection_retries: 12
 jenkins_hostname: localhost
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
   shell: curl --head --silent http://{{ jenkins_hostname }}:8080/cli/
   register: result
   until: result.stdout.find("200 OK") != -1
-  retries: {{ jenkins_connection_retries }}
-  delay: {{ jenkins_connection_delay }}
+  retries: "{{ jenkins_connection_retries }}"
+  delay: "{{ jenkins_connection_delay }}"
   changed_when: false
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,8 +28,8 @@
   shell: curl --head --silent http://{{ jenkins_hostname }}:8080/cli/
   register: result
   until: result.stdout.find("200 OK") != -1
-  retries: 12
-  delay: 5
+  retries: {{ jenkins_connection_retries }}
+  delay: {{ jenkins_connection_delay }}
   changed_when: false
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.


### PR DESCRIPTION
### Reviewers

- [x] @geerlingguy 

cc: 
### High level summary

My vagrant still failed to provision due to Jenkins throwing a 503 after 60 seconds. Let's use the same validation but allow consumers of this role to configure how long they're willing to wait.

:cry: 

### Approach

Extrapolate out the hard-coded timeout and retries to be variables.