### PR TITLE
Correclty ensure that jenkins has started.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,9 +25,9 @@
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
-  shell: curl --head --silent http://{{ jenkins_hostname }}:8080/cli/
+  shell: curl -D - --silent http://{{ jenkins_hostname }}:8080/cli/
   register: result
-  until: result.stdout.find("200 OK") != -1
+  until: (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false


### PR DESCRIPTION
The fact that the http port is open is not complete indication of Jenkins restart.
It can happen sometimes that Jenkins needs more time to start completely.
Thank you.