### PR TITLE
Allow hosting with a path prefix, e.g. /ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ This role will install the latest version of Jenkins by default (using the offic
     jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian-stable binary/
     jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key
 
+### Optional Variables
+
+Optional variables that are not defined by default are listed below, along with example values
+
+    jenkins_url_prefix: '/ci'
+
+This will add `--prefix=/ci` to the Jenkins initialization `java` invocation, and will cause the Jenkins instance to be hosted with a `/ci` path prefix (e.g. http://www.example.com/ci). This is particularly useful for hosting Jenkins behind a reverse proxy.
+
 ## Dependencies
 
   - geerlingguy.java

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,7 +25,7 @@
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
-  shell: curl --head --silent http://{{ jenkins_hostname }}:8080/cli/
+  shell: curl --head --silent http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix | default('') }}/cli/
   register: result
   until: result.stdout.find("200 OK") != -1
   retries: "{{ jenkins_connection_retries }}"
@@ -34,7 +34,7 @@
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
   get_url:
-    url: "http://{{ jenkins_hostname }}:8080/jnlpJars/jenkins-cli.jar"
+    url: "http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix | default('') }}/jnlpJars/jenkins-cli.jar"
     dest: "{{ jenkins_jar_location }}"
   register: jarfile_get
   until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,7 +23,7 @@
 
 - name: Install Jenkins plugins.
   command: >
-    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:8080/ install-plugin {{ item }}
+    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix | default('') }}/ install-plugin {{ item }}
     creates=/var/lib/jenkins/plugins/{{ item }}.jpi
   with_items: jenkins_plugins
   notify: restart jenkins

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,3 +15,27 @@
 
 - name: Ensure Jenkins is installed.
   apt: pkg=jenkins state=installed
+
+- name: Add URL prefix to /etc/default/jenkins
+  lineinfile:
+    dest: /etc/default/jenkins
+    insertafter: '^JENKINS_ARGS='
+    line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
+  when: jenkins_url_prefix is defined
+  register: init_config
+
+- name: Restart Jenkins on init config change
+  service: name=jenkins state=restarted
+  when: init_config.changed
+
+- name: Remove URL prefix from /etc/default/jenkins
+  lineinfile:
+    dest: /etc/default/jenkins
+    regexp: '^JENKINS_ARGS\+=" --prefix=.+'
+    state: absent
+  when: jenkins_url_prefix is not defined
+  register: init_config
+
+- name: Restart Jenkins on init config change
+  service: name=jenkins state=restarted
+  when: init_config.changed

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -14,3 +14,27 @@
 
 - name: Ensure Jenkins is installed.
   yum: pkg=jenkins state=installed
+
+- name: Add URL prefix to /etc/sysconfig/jenkins
+  lineinfile:
+    dest: /etc/sysconfig/jenkins
+    insertafter: '^JENKINS_ARGS='
+    line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
+  when: jenkins_url_prefix is defined
+  register: init_config
+
+- name: Restart Jenkins on init config change
+  service: name=jenkins state=restarted
+  when: init_config.changed
+
+- name: Remove URL prefix from /etc/sysconfig/jenkins
+  lineinfile:
+    dest: /etc/sysconfig/jenkins
+    regexp: '^JENKINS_ARGS\+=" --prefix=.+'
+    state: absent
+  when: jenkins_url_prefix is not defined
+  register: init_config
+
+- name: Restart Jenkins on init config change
+  service: name=jenkins state=restarted
+  when: init_config.changed


### PR DESCRIPTION
Sometimes it is desirable to put Jenkins behind a reverse proxy, which most likely requires a path prefix in the URL, e.g. http://www.example.com/ci/.

We can achieve this by parsing the "--prefix" argument in the invocation of Jenkins in /etc/default/jenkins.