### PR TITLE
Fix waiting for startup when security is enabled

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: Wait for Jenkins to start up before proceeding.
   shell: "curl -D - --silent http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix }}/cli/"
   register: result
-  until: (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
+  until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false


### PR DESCRIPTION
A secured Jenkins changes its HTTP status from "200 OK: Please wait while ..." to "403 Forbidden" when it starts (and not to "200 OK" like an unsecured Jenkins).

Without this commit the role hangs if Jenkins' security has been enabled after the initial installation. Other than that, the role works fine with a secured Jenkins as long as the Unix user's public key has been added to a Jenkins user with administrator permissions.