### PR TITLE
Fixes #23: Allow to configure the HTTP port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,13 @@ python: "2.7"
 env:
   - SITE=test.yml
     PREFIX=''
+    HTTP_PORT=8080
   - SITE=test-prefix.yml
     PREFIX='jenkins'
+    HTTP_PORT=8080
+  - SITE=test-http-port.yml
+    PREFIX=''
+    HTTP_PORT=8081
 
 before_install:
   - sudo apt-get update -qq
@@ -37,4 +42,4 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Make sure Jenkins is running.
-  - curl http://localhost:8080/$PREFIX
+  - curl http://localhost:$HTTP_PORT/$PREFIX

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `vars/main.
 
 The system hostname; usually `localhost` works fine. This will be used during setup to communicate with the running Jenkins instance via HTTP requests.
 
+    jenkins_http_port: 8080
+
+The HTTP port for Jenkins' web interface.
+
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_hostname: localhost
+jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins:
   - git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
-  shell: "curl -D - --silent http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix }}/cli/"
+  shell: "curl -D - --silent http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
   register: result
   until: (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
   retries: "{{ jenkins_connection_retries }}"
@@ -37,7 +37,7 @@
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
   get_url:
-    url: "http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix }}/jnlpJars/jenkins-cli.jar"
+    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/jnlpJars/jenkins-cli.jar"
     dest: "{{ jenkins_jar_location }}"
   register: jarfile_get
   until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,7 +23,7 @@
 
 - name: Install Jenkins plugins.
   command: >
-    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:8080{{ jenkins_url_prefix | default('') }}/ install-plugin {{ item }}
+    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ install-plugin {{ item }}
     creates=/var/lib/jenkins/plugins/{{ item }}.jpi
   with_items: jenkins_plugins
   notify: restart jenkins

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -6,14 +6,18 @@
     line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
   register: jenkins_init_config
 
+- name: Immediately restart Jenkins on init config changes.
+  service: name=jenkins state=restarted
+  when: jenkins_init_config.changed
+
 - name: Set HTTP port in Jenkins config.
   lineinfile:
     backrefs: yes
     dest: "{{ jenkins_init_file }}"
     regexp: '^{{ jenkins_http_port_param }}='
     line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
-  register: jenkins_init_config
+  register: jenkins_http_config
 
-- name: Immediately restart Jenkins on init config changes.
+- name: Immediately restart Jenkins on http config changes.
   service: name=jenkins state=restarted
-  when: jenkins_init_config.changed
+  when: jenkins_http_config.changed

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -6,6 +6,14 @@
     line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
   register: jenkins_init_config
 
+- name: Set HTTP_PORT in Jenkins config.
+  lineinfile:
+    backrefs: yes
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_http_port_param }}='
+    line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
+  register: jenkins_init_config
+
 - name: Immediately restart Jenkins on init config changes.
   service: name=jenkins state=restarted
   when: jenkins_init_config.changed

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -6,7 +6,7 @@
     line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
   register: jenkins_init_config
 
-- name: Set HTTP_PORT in Jenkins config.
+- name: Set HTTP port in Jenkins config.
   lineinfile:
     backrefs: yes
     dest: "{{ jenkins_init_file }}"

--- a/tests/test-http-port.yml
+++ b/tests/test-http-port.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  remote_user: root
+
+  vars:
+    - jenkins_http_port: 8081
+
+  roles:
+    - geerlingguy.java
+    - ansible-role-jenkins

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,4 @@
 __jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian binary/
 __jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
 jenkins_init_file: /etc/default/jenkins
+jenkins_http_port_param: HTTP_PORT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,4 @@
 __jenkins_repo_url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
 __jenkins_repo_key_url: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
 jenkins_init_file: /etc/sysconfig/jenkins
+jenkins_http_port_param: JENKINS_PORT


### PR DESCRIPTION
The HTTP port is configurable with the 'jenkins_http_port' variable.

For Debian/Ubuntu, the configuration variable HTTP_PORT is used.
For RedHat/CentOS, the configuration variable JENKINS_PORT is used.

The default port value is 8080.

Change-Id: I6f2a8e027e8a2a04186b0a26789ffb524f5ac58a