### PR TITLE
README: Fix formatting in description of jenkins_url_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Jenkins plugins to be installed automatically during provisioning. You can alway
 
     jenkins_url_prefix: ""
 
-Used for setting a URL prefix for your Jenkins installation. The option is added as `--prefix={{ jenkins_url_prefix }}` to the Jenkins initialization `java` invocation, so you can access the installation at a path like `http://www.example.com/{{ jenkins_url_prefix }}. Make sure you start the prefix with a `/` (e.g. `/jenkins`).
+Used for setting a URL prefix for your Jenkins installation. The option is added as `--prefix={{ jenkins_url_prefix }}` to the Jenkins initialization `java` invocation, so you can access the installation at a path like `http://www.example.com{{ jenkins_url_prefix }}`. Make sure you start the prefix with a `/` (e.g. `/jenkins`).
 
     jenkins_connection_delay: 5
     jenkins_connection_retries: 60


### PR DESCRIPTION
- Add missing closing backtick which was causing the rest of the
  sentence to be rendered as code.

- Remove superfluous slash in example. The jenkins_url_prefix is
  expected to begin with a slash, so it's not necessary to put
  one before its usage.

Change-Id: I0a56296b714d8ec3e83aa03fad1ccfe864da337c