### PR TITLE
Fixes: #33: Support changes to jenkins_url_prefix

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -3,6 +3,7 @@
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     insertafter: '^JENKINS_ARGS='
+    regexp: '^JENKINS_ARGS\+=" --prefix='
     line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
   register: jenkins_init_config
 


### PR DESCRIPTION
Add a 'regexp' line to the URL prefixing so that we don't
insert multiple lines for defining --prefix when we change
jenkins_url_prefix.
