### PR TITLE
Issues when upgrading package via apt-get

### DIFF
--- a/tasks/prefix.yml
+++ b/tasks/prefix.yml
@@ -3,7 +3,7 @@
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     insertafter: '^JENKINS_ARGS='
-    line: 'JENKINS_ARGS+=" --prefix={{ jenkins_url_prefix }}"'
+    line: 'JENKINS_ARGS="$JENKINS_ARGS --prefix={{ jenkins_url_prefix }}"'
   register: jenkins_init_config
 
 - name: Restart Jenkins if config changed.


### PR DESCRIPTION
Causes an exception of:

```
/var/lib/dpkg/info/jenkins.postinst: 76: /etc/default/jenkins: JENKINS_ARGS+= --prefix=: not found
dpkg: error processing package jenkins (--configure):
subprocess installed post-installation script returned error exit status 127
```

Figured I'd just go and fix it.