### PR TITLE
add ajp port config support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   - >
     SITE=test-ajp-port.yml
     PREFIX=''
-    HTTP_PORT=-1
+    AJP_PORT=-1
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
     SITE=test-http-port.yml
     PREFIX=''
     HTTP_PORT=8081
+  - >
+    SITE=test-ajp-port.yml
+    PREFIX=''
+    HTTP_PORT=-1
 
 before_install:
   - sudo apt-get update -qq

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_hostname: localhost
 jenkins_http_port: 8080
+jenkins_ajp_port: -1
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins:
   - git

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -19,6 +19,14 @@
     line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
   register: jenkins_http_config
 
+- name: Set AJP port in Jenkins config.
+  lineinfile:
+    backrefs: yes
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_ajp_port_param }}='
+    line: '{{ jenkins_ajp_port_param }}={{ jenkins_ajp_port }}'
+  register: jenkins_ajp_config
+
 - name: Immediately restart Jenkins on http config changes.
   service: name=jenkins state=restarted
-  when: jenkins_http_config.changed
+  when: jenkins_http_config.changed or jenkins_ajp_config.changed 

--- a/tests/test-ajp-port.yml
+++ b/tests/test-ajp-port.yml
@@ -1,0 +1,10 @@
+---
+- hosts: localhost
+  remote_user: root
+
+  vars:
+    - jenkins_ajp_port: 8009
+
+  roles:
+    - geerlingguy.java
+    - ansible-role-jenkins

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -3,3 +3,4 @@ __jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian binary/
 __jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT
+jenkins_ajp_port_param: AJP_PORT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,3 +3,4 @@ __jenkins_repo_url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
 __jenkins_repo_key_url: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT
+jenkins_ajp_port_param: JENKINS_AJP_PORT


### PR DESCRIPTION
Hi, for some reason the version of jenkins 2.0 (on redhat) blows up if the AJP port is set (because winstone 3.0 fails to bootstrap that port) 
I added a parameter (forgive my lack of terminology) to the to be able to make the AJP configurable
