### PR TITLE
Disable Jenkins 2.0 Setup Wizard

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -1,4 +1,11 @@
 ---
+- name: Ensure SetupWizard is disabled in Jenkins config.
+  lineinfile:
+    backrefs: yes
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_JAVA_OPTIONS="(.*)(?<! -Djenkins.install.runSetupWizard=false)"$'
+    line: 'JENKINS_JAVA_OPTIONS="\1 -Djenkins.install.runSetupWizard=false"'
+
 - name: Ensure URL prefix is present in Jenkins config.
   lineinfile:
     dest: "{{ jenkins_init_file }}"


### PR DESCRIPTION
Jenkins 2.0 introduces an interactive Setup Wizard which breaks
automatic configuration. The Setup Wizard needs to be disabled before
Jenkins is starting for the first time.