### PR TITLE
#50 Fixed Avoid 2.0 setup wizard but provide secure-by-default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The system hostname; usually `localhost` works fine. This will be used during se
 
 The HTTP port for Jenkins' web interface.
 
+    jenkins_admin: { username: admin, password: admin }
+
+The Default built-in Jenkins admin credentials.
+
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins: []
 jenkins_url_prefix: ""
+jenkins_admin: { username: admin, password: admin }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,3 +46,7 @@
 
 # Update Jenkins and install configured plugins.
 - include: plugins.yml
+
+# Remove init.groovy.d/basic-security settings
+- name: Remove Jenkins security init scripts
+  shell: "rm -f /var/lib/jenkins/init.groovy.d/basic-security.groovy"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,4 +49,4 @@
 
 # Remove init.groovy.d/basic-security settings
 - name: Remove Jenkins security init scripts
-  shell: "rm -f /var/lib/jenkins/init.groovy.d/basic-security.groovy"
+  file: path=/var/lib/jenkins/init.groovy.d/basic-security.groovy state=absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
-  shell: "curl -D - --silent http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
+  shell: "curl -D - --silent -m 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
   register: result
   until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
   retries: "{{ jenkins_connection_retries }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,7 +23,7 @@
 
 - name: Install Jenkins plugins.
   command: >
-    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ install-plugin {{ item }}
+    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/ install-plugin {{ item }} --username {{ jenkins_admin.username }} --password {{ jenkins_admin.password }}
     creates=/var/lib/jenkins/plugins/{{ item }}.jpi
   with_items: "{{ jenkins_plugins }}"
   notify: restart jenkins

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -20,6 +20,14 @@
     line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
   register: jenkins_http_config
 
-- name: Immediately restart Jenkins on http config changes.
+- name: Create custom init scripts directory
+  file: path=/var/lib/jenkins/init.groovy.d state=directory owner=jenkins group=jenkins mode=0775
+
+- name: Configure Jenkins default users.
+  template: src=basic-security.groovy dest=/var/lib/jenkins/init.groovy.d/basic-security.groovy
+  register: jenkins_users_config
+
+
+- name: Immediately restart Jenkins on http users changes.
   service: name=jenkins state=restarted
-  when: jenkins_http_config.changed
+  when: jenkins_users_config.changed

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,5 +13,8 @@
     state: present
     update_cache: yes
 
+- name: Update apt cache.
+  apt: update_cache=yes cache_valid_time=86400
+  
 - name: Ensure Jenkins is installed.
-  apt: name=jenkins state=installed
+  apt: name=jenkins state=present

--- a/templates/basic-security.groovy
+++ b/templates/basic-security.groovy
@@ -1,0 +1,16 @@
+#!groovy
+
+import jenkins.model.*
+import hudson.security.*
+
+def instance = Jenkins.getInstance()
+
+println "--> creating local user 'admin'"
+
+def hudsonRealm = new HudsonPrivateSecurityRealm(false)
+hudsonRealm.createAccount('{{ jenkins_admin.username }}','{{ jenkins_admin.password }}')
+instance.setSecurityRealm(hudsonRealm)
+
+def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+instance.setAuthorizationStrategy(strategy)
+instance.save()

--- a/templates/basic-security.groovy
+++ b/templates/basic-security.groovy
@@ -1,16 +1,19 @@
 #!groovy
-
-import jenkins.model.*
 import hudson.security.*
+import jenkins.model.*
 
 def instance = Jenkins.getInstance()
 
-println "--> creating local user 'admin'"
+println "--> Checking if security has been set already"
 
-def hudsonRealm = new HudsonPrivateSecurityRealm(false)
-hudsonRealm.createAccount('{{ jenkins_admin.username }}','{{ jenkins_admin.password }}')
-instance.setSecurityRealm(hudsonRealm)
+if (!instance.isUseSecurity()) {
+    println "--> creating local user 'admin'"
 
-def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
-instance.setAuthorizationStrategy(strategy)
-instance.save()
+    def hudsonRealm = new HudsonPrivateSecurityRealm(false)
+    hudsonRealm.createAccount('{{ jenkins_admin.username }}', '{{ jenkins_admin.password }}')
+    instance.setSecurityRealm(hudsonRealm)
+
+    def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+    instance.setAuthorizationStrategy(strategy)
+    instance.save()
+}


### PR DESCRIPTION
Simply implemented the fixes discussed in issue #50 .
Allows a simple admin account setup.
Tested on debian / ubuntu.