### PR TITLE
Allow pinning of Jenkins version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,13 @@ env:
     site: test.yml
     prefix: ''
     http_port: 8080
+  - distribution: centos
+    version: 6
+    init: /sbin/init
+    run_opts: ""
+    site: test-jenkins-version.yml
+    prefix: ''
+    http_port: 8080
   # - distribution: centos
   #   version: 7
   #   init: /usr/lib/systemd/systemd
@@ -44,6 +51,13 @@ env:
     run_opts: ""
     site: test-prefix.yml
     prefix: jenkins
+    http_port: 8080
+  - distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
+    site: test-jenkins-version.yml
+    prefix: ''
     http_port: 8080
 
 services:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 
 Jenkins plugins to be installed automatically during provisioning. (_Note_: This feature is currently undergoing some changes due to the `jenkins-cli` authentication changes in Jenkins 2.0, and may not work as expected.)
 
+    jenkins_version: 1.644
+
+Jenkins version can be pinned to any version available on http://pkg.jenkins-ci.org/debian/ or http://pkg.jenkins-ci.org/redhat/ (depending on the {{ ansible_os_family }}).
+
+    jenkins_pkg_url: http://example.com/
+
+If the Jenkins version you need is not available in http://pkg.jenkins-ci.org/debian/ or http://pkg.jenkins-ci.org/redhat/, the URL can be customized by setting jenkins_pkg_url (_Note_: the role depends on the same naming convention that http://pkg.jenkins-ci.org/ uses).
+
     jenkins_url_prefix: ""
 
 Used for setting a URL prefix for your Jenkins installation. The option is added as `--prefix={{ jenkins_url_prefix }}` to the Jenkins initialization `java` invocation, so you can access the installation at a path like `http://www.example.com{{ jenkins_url_prefix }}`. Make sure you start the prefix with a `/` (e.g. `/jenkins`).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,11 @@
     jenkins_repo_key_url: "{{ __jenkins_repo_key_url }}"
   when: jenkins_repo_key_url is not defined
 
+- name: Define jenkins_pkg_url
+  set_fact:
+    jenkins_pkg_url: "{{ __jenkins_pkg_url }}"
+  when: jenkins_pkg_url is not defined
+
 # Setup/install tasks.
 - include: setup-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -13,5 +13,21 @@
     state: present
     update_cache: yes
 
+- name: Download specific Jenkins version.
+  get_url:
+    url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
+    dest: "/tmp/jenkins.deb"
+  when: jenkins_version is defined
+
+- stat: path="/tmp/jenkins.deb"
+  register: specific_version
+
+- name: Install correct version of Jenkins is installed.
+  apt:
+    deb="/tmp/jenkins.deb"
+    state=installed
+  when: specific_version.stat.exists
+
 - name: Ensure Jenkins is installed.
   apt: name=jenkins state=installed
+  when: jenkins_version is undefined

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,5 +12,19 @@
     state: present
     key: "{{ jenkins_repo_key_url }}"
 
+- name: Download specific Jenkins version.
+  get_url:
+    url: "{{ jenkins_pkg_url }}/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
+    dest: "/tmp/jenkins.rpm"
+  when: jenkins_version is defined
+
+- stat: path="/tmp/jenkins.rpm"
+  register: specific_version
+
+- name: Install correct version of Jenkins is installed.
+  yum: name="/tmp/jenkins.rpm" state=present
+  when: specific_version.stat.exists
+
 - name: Ensure Jenkins is installed.
   yum: name=jenkins state=installed
+  when: jenkins_version is undefined

--- a/tests/test-jenkins-version.yml
+++ b/tests/test-jenkins-version.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  vars:
+    - jenkins_version: 1.644
+
+  roles:
+    - geerlingguy.java
+    - role_under_test

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,6 @@
 ---
 __jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian binary/
 __jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
+__jenkins_pkg_url: http://pkg.jenkins-ci.org/debian/binary
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,6 @@
 ---
 __jenkins_repo_url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
 __jenkins_repo_key_url: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
+__jenkins_pkg_url: http://pkg.jenkins-ci.org/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT


### PR DESCRIPTION
Hi Geerlingguy, 

A while back I saw the issue #38. This seems to have been closed now, but without resolution as far as I can tell. I'm planning on using this role to maintain a production instance of Jenkins, and as such I need to be able to pin the Jenkins version, and potentially down the line, also plugin versions. 

I forked your project to see if there was an easy way to do this. And as it turns out we can do pinning of Jenkins version without changing any of the core behavior of your role. Would you be interested in pulling this in? And if so, how would you feel about an upcoming diff addressing my other problem i.e. _optionally_ pinning versions of plugins? 