### PR TITLE
Fixes #50 - Avoid 2.0 setup wizard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,10 @@ script:
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/$site'
 
   # Test role idempotence.
+  - idempotence=$(mktemp)
+  - sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/$site | tee -a ${idempotence}
   - >
-    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/$site
+    tail ${idempotence}
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,6 @@ jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins: []
 jenkins_url_prefix: ""
+jenkins_home: "/var/lib/jenkins"
+jenkins_user: "jenkins"
+jenkins_setup_wizard: False

--- a/tasks/avoid-setup-wizard.yml
+++ b/tasks/avoid-setup-wizard.yml
@@ -11,9 +11,10 @@
     delay: 3
 
   - name: Bypass - jenkins.install.InstallUtil.lastExecVersion
-    copy: src={{ jenkins_home }}/jenkins.install.UpgradeWizard.state
-          dest={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
-          remote_src=True
+    copy: >
+      src={{ jenkins_home }}/jenkins.install.UpgradeWizard.state
+      dest={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
+      remote_src=True
     when: lastexecversion.stat.exists == False and ansible_version.major >= 2
 
   - name: Bypass - jenkins.install.InstallUtil.lastExecVersion
@@ -30,8 +31,10 @@
 
   # keep it for the Jenkins CLI --password-file argument
   - name: Bypass - initialAdminPassword
-    shell: mv {{ jenkins_home }}/secrets/initialAdminPassword /root
-           creates=/root/initialAdminPassword
+    shell: >
+      mv {{ jenkins_home }}/secrets/initialAdminPassword /root
+      creates=/root/initialAdminPassword
+    failed_when: false
     when: adminpassword.stat.exists == True
 
   - name: restart jenkins

--- a/tasks/avoid-setup-wizard.yml
+++ b/tasks/avoid-setup-wizard.yml
@@ -3,6 +3,13 @@
     stat: path={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
     register: lastexecversion
 
+  - name: Ensure jenkins.install.UpgradeWizard.state
+    stat: path={{ jenkins_home }}/jenkins.install.UpgradeWizard.state
+    register: upgradewizard
+    until: upgradewizard.stat.exists == True
+    retries: 12
+    delay: 3
+
   - name: Bypass - jenkins.install.InstallUtil.lastExecVersion
     copy: src={{ jenkins_home }}/jenkins.install.UpgradeWizard.state
           dest={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion

--- a/tasks/avoid-setup-wizard.yml
+++ b/tasks/avoid-setup-wizard.yml
@@ -31,6 +31,7 @@
   # keep it for the Jenkins CLI --password-file argument
   - name: Bypass - initialAdminPassword
     shell: mv {{ jenkins_home }}/secrets/initialAdminPassword /root
+           creates=/root/initialAdminPassword
     when: adminpassword.stat.exists == True
 
   - name: restart jenkins

--- a/tasks/avoid-setup-wizard.yml
+++ b/tasks/avoid-setup-wizard.yml
@@ -1,0 +1,20 @@
+---
+  - name: Bypass - jenkins.install.InstallUtil.lastExecVersion
+    copy: src={{ jenkins_home }}/jenkins.install.UpgradeWizard.state
+          dest={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
+          owner={{ jenkins_user }}
+          group={{ jenkins_user }}
+          remote_src=True
+
+  - stat: path={{ jenkins_home }}/secrets/initialAdminPassword
+    register: adminpassword
+
+  # keep it for the Jenkins CLI --password-file argument
+  - name: Bypass - initialAdminPassword
+    shell: mv {{ jenkins_home }}/secrets/initialAdminPassword /root
+    when: adminpassword.stat.exists == True
+
+  - name: restart jenkins
+    service: name=jenkins state=restarted
+    when: adminpassword.stat.exists == True
+

--- a/tasks/avoid-setup-wizard.yml
+++ b/tasks/avoid-setup-wizard.yml
@@ -1,10 +1,22 @@
 ---
+  - name: stat jenkins.install.InstallUtil.lastExecVersion
+    stat: path={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
+    register: lastexecversion
+
   - name: Bypass - jenkins.install.InstallUtil.lastExecVersion
     copy: src={{ jenkins_home }}/jenkins.install.UpgradeWizard.state
           dest={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
+          remote_src=True
+    when: lastexecversion.stat.exists == False and ansible_version.major >= 2
+
+  - name: Bypass - jenkins.install.InstallUtil.lastExecVersion
+    shell: cp {{ jenkins_home }}/jenkins.install.UpgradeWizard.state {{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
+    when: lastexecversion.stat.exists == False and ansible_version.major < 2
+
+  - name: ownership - jenkins.install.InstallUtil.lastExecVersion
+    file: path={{ jenkins_home }}/jenkins.install.InstallUtil.lastExecVersion
           owner={{ jenkins_user }}
           group={{ jenkins_user }}
-          remote_src=True
 
   - stat: path={{ jenkins_home }}/secrets/initialAdminPassword
     register: adminpassword

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,10 @@
 # Configure Jenkins init settings.
 - include: settings.yml
 
+# Avoid Jenkins 2 setup wizard
+- include: avoid-setup-wizard.yml
+  when: jenkins_setup_wizard == False
+
 # Make sure Jenkins starts, then configure Jenkins.
 - name: Ensure Jenkins is started and runs on startup.
   service: name=jenkins state=started enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,13 +23,13 @@
 # Configure Jenkins init settings.
 - include: settings.yml
 
-# Avoid Jenkins 2 setup wizard
-- include: avoid-setup-wizard.yml
-  when: jenkins_setup_wizard == False
-
 # Make sure Jenkins starts, then configure Jenkins.
 - name: Ensure Jenkins is started and runs on startup.
   service: name=jenkins state=started enabled=yes
+
+# Avoid Jenkins 2 setup wizard
+- include: avoid-setup-wizard.yml
+  when: jenkins_setup_wizard == False
 
 - name: Wait for Jenkins to start up before proceeding.
   shell: "curl -D - --silent http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"


### PR DESCRIPTION
I prefer to push an include with a jenkins_setup_wizard flag, in order to separate this particular trick.

I validate this for Debian / Ubuntu. So maybe you have to adjust (espacially the the jenkins_home) for RedHat.