### PR TITLE
Fixes #29 - setting jnlp port

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 
     jenkins_jnlp_port_param: 0
 
-In order to use the jenkins-cli you need to setup a jnlp port. When Jenkins is installed, this value is -1 which means _disabled_. By default, this role set it to 0 which means _random_. You can set it to another regular port value.
+The TCP port for JNLP agents. -1 means _disabled_, 0 means _random_. You can set it to another regular port value.
 
     jenkins_plugins: []
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ A file (with full path) on the Jenkins server containing the admin token. If thi
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.
 
+    jenkins_jnlp_port_param: 0
+
+In order to use the jenkins-cli you need to setup a jnlp port. When Jenkins is installed, this value is -1 which means _disabled_. By default, this role set it to 0 which means _random_. You can set it to another regular port value.
+
     jenkins_plugins: []
 
 Jenkins plugins to be installed automatically during provisioning.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 jenkins_plugin_updates_expiration: 86400
 jenkins_plugin_timeout: 30
+jenkins_jnlp_port_param: 0
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -62,14 +62,14 @@
   retries: 20
   delay: 3
 
-- name: set TCP port for JNLP
+- name: Set TCP port for JNLP agents in Jenkins config.
   lineinfile:
-     dest="{{ jenkins_home }}/config.xml"
-     regexp='<slaveAgentPort>'
-     line='  <slaveAgentPort>{{ jenkins_jnlp_port_param }}</slaveAgentPort>'
+     dest: "{{ jenkins_home }}/config.xml"
+     regexp: '<slaveAgentPort>'
+     line: '  <slaveAgentPort>{{ jenkins_jnlp_port_param }}</slaveAgentPort>'
   register: jenkins_jnlp_port
 
-- name: Immediately restart Jenkins on http or user changes.
+- name: Immediately restart Jenkins on TCP port for JNLP agents changes.
   service: name=jenkins state=restarted
   when: (jenkins_jnlp_port is defined and jenkins_jnlp_port.changed)
 

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -53,3 +53,23 @@
   when: (jenkins_users_config is defined and jenkins_users_config.changed) or
         (jenkins_http_config is defined and jenkins_http_config.changed) or
         (jenkins_home_config is defined and jenkins_home_config.changed)
+
+- name: Ensure config.xml is present.
+  stat:
+    path: "{{ jenkins_home }}/config.xml"
+  register: configxml
+  until: configxml.stat.exists == True
+  retries: 20
+  delay: 3
+
+- name: set TCP port for JNLP
+  lineinfile:
+     dest="{{ jenkins_home }}/config.xml"
+     regexp='<slaveAgentPort>'
+     line='  <slaveAgentPort>{{ jenkins_jnlp_port_param }}</slaveAgentPort>'
+  register: jenkins_jnlp_port
+
+- name: Immediately restart Jenkins on http or user changes.
+  service: name=jenkins state=restarted
+  when: (jenkins_jnlp_port is defined and jenkins_jnlp_port.changed)
+


### PR DESCRIPTION
The default value is different from the original value, in order to allow the plugins installation.
