### PR TITLE
Configurable HTTP listen address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ env:
     prefix: ''
     http_port: 8081
 
+  # tests/test-http-listen-address.yml
+  - distro: ubuntu1604
+    playbook: test-http-listen-address.yml
+    prefix: ''
+    http_port: 8080
+
   # tests/test-prefix.yml
   - distro: ubuntu1604
     playbook: test-prefix.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The Jenkins home directory which, amongst others, is being used for storing arti
 
 The HTTP port for Jenkins' web interface.
 
+    jenkins_http_listen_address: 0.0.0.0
+
+The address Jenkins' web interface should bind to. If set to anything other than `0.0.0.0`, be sure to avoid conflicts with `jenkins_hostname` (for example, if `jenkins_hostname` is `localhost`, `127.0.0.1` will still work perfectly fine for this).
+
     jenkins_admin_username: admin
     jenkins_admin_password: admin
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,7 @@ jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
+jenkins_http_listen_address: 0.0.0.0
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"

--- a/tasks/listen-Debian.yml
+++ b/tasks/listen-Debian.yml
@@ -1,0 +1,8 @@
+---
+- name: Set HTTP listen address in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    insertafter: '^JENKINS_ARGS='
+    regexp: '^JENKINS_ARGS\+=" --httpListenAddress='
+    line: 'JENKINS_ARGS+=" --httpListenAddress={{ jenkins_http_listen_address }}"'
+  register: jenkins_http_listen_address_config

--- a/tasks/listen-RedHat.yml
+++ b/tasks/listen-RedHat.yml
@@ -1,0 +1,8 @@
+---
+- name: Set HTTP listen address in Jenkins config.
+  lineinfile:
+    backrefs: yes
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_LISTEN_ADDRESS='
+    line: 'JENKINS_LISTEN_ADDRESS={{ jenkins_http_listen_address }}'
+  register: jenkins_http_listen_address_config

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -27,7 +27,14 @@
     dest: "{{ jenkins_init_file }}"
     regexp: '^{{ jenkins_http_port_param }}='
     line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
-  register: jenkins_http_config
+  register: jenkins_http_port_config
+
+# Set HTTP listen address. Registers jenkins_http_listen_address_config.
+- include: listen-RedHat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: listen-Debian.yml
+  when: ansible_os_family == 'Debian'
 
 - name: Ensure jenkins_home {{ jenkins_home }} exists
   file:
@@ -51,5 +58,6 @@
 - name: Immediately restart Jenkins on http or user changes.
   service: name=jenkins state=restarted
   when: (jenkins_users_config is defined and jenkins_users_config.changed) or
-        (jenkins_http_config is defined and jenkins_http_config.changed) or
+        (jenkins_http_port_config is defined and jenkins_http_port_config.changed) or
+        (jenkins_http_listen_address_config is defined and jenkins_http_listen_address_config.changed) or
         (jenkins_home_config is defined and jenkins_home_config.changed)

--- a/tests/test-http-listen-address.yml
+++ b/tests/test-http-listen-address.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_http_listen_address: 127.0.0.1
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - role_under_test


### PR DESCRIPTION
Adds the ability to configure Jenkins' HTTP listen address - sometimes listening on `0.0.0.0` isn't practical for a variety of reasons.

The semantics are a bit different between Debianoids and Red Hat-oids due to differing init configs/scripts from the upstream Jenkins packages, so separate `tasks/` files are used per-platform. More than happy to move things around if that defies convention / doesn't work for some other reason. It felt like a misuse of vars due to the need for conditional regex parts, and using task conditionals with `when:` had a confusing output presentation.

I've tested this manually on all the Dockerfiles available in `tests/` (except CentOS 7, which incidentally is the platform I use the role for - already tested in production) to ensure that the socket is bound to the specified address.
