### PR TITLE
Dockerfile improvement: Lighter (~20%)

### DIFF
--- a/tests/Dockerfile.centos-6
+++ b/tests/Dockerfile.centos-6
@@ -2,9 +2,8 @@ FROM centos:6
 
 # Install Ansible
 RUN yum -y update; yum clean all;
-RUN yum -y install epel-release
-RUN yum -y install git ansible sudo
-RUN yum clean all
+RUN yum -y install epel-release; yum clean all;
+RUN yum -y install git ansible sudo; yum clean all;
 
 # Disable requiretty
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers

--- a/tests/Dockerfile.centos-6
+++ b/tests/Dockerfile.centos-6
@@ -1,9 +1,15 @@
 FROM centos:6
+MAINTAINER Jeff Geerling
 
 # Install Ansible
-RUN yum -y update; yum clean all;
-RUN yum -y install epel-release; yum clean all;
-RUN yum -y install git ansible sudo; yum clean all;
+RUN yum makecache fast \
+ && yum -y install deltarpm epel-release \
+ && yum -y update \
+ && yum -y install \
+      ansible \
+      git \
+      sudo \
+ && yum clean all
 
 # Disable requiretty
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -1,4 +1,5 @@
 FROM centos:7
+MAINTAINER Jeff Geerling
 
 # Install systemd -- See https://hub.docker.com/_/centos/
 RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
@@ -13,8 +14,14 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible
-RUN yum -y install epel-release; yum clean all
-RUN yum -y install git ansible sudo; yum clean all
+RUN yum makecache fast \
+ && yum -y install deltarpm epel-release \
+ && yum -y update \
+ && yum -y install \
+      ansible \
+      git \
+      sudo \
+ && yum clean all
 
 # Disable requiretty
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -13,9 +13,8 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible
-RUN yum -y install epel-release
-RUN yum -y install git ansible sudo
-RUN yum clean all
+RUN yum -y install epel-release; yum clean all
+RUN yum -y install git ansible sudo; yum clean all
 
 # Disable requiretty
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers

--- a/tests/Dockerfile.ubuntu-12.04
+++ b/tests/Dockerfile.ubuntu-12.04
@@ -18,6 +18,7 @@ RUN apt-add-repository -y ppa:ansible/ansible \
        ansible \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && touch -m -t 200101010101.01 /var/lib/apt/periodic/update-success-stamp \
     && apt-get clean
 
 # Install Ansible inventory file

--- a/tests/Dockerfile.ubuntu-12.04
+++ b/tests/Dockerfile.ubuntu-12.04
@@ -1,11 +1,24 @@
 FROM ubuntu:12.04
-RUN apt-get update
+MAINTAINER Jeff Geerling
 
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       software-properties-common \
+       python-software-properties \
+       git \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
 # Install Ansible
-RUN apt-get install -y software-properties-common python-software-properties git
-RUN apt-add-repository -y ppa:ansible/ansible
-RUN apt-get update
-RUN apt-get install -y ansible
+RUN apt-add-repository -y ppa:ansible/ansible \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ansible \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
 
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-14.04
+++ b/tests/Dockerfile.ubuntu-14.04
@@ -1,11 +1,22 @@
 FROM ubuntu:14.04
-RUN apt-get update
+MAINTAINER Jeff Geerling
 
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       software-properties-common git \
+    && rm -Rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
 # Install Ansible
-RUN apt-get install -y software-properties-common git
-RUN apt-add-repository -y ppa:ansible/ansible
-RUN apt-get update
-RUN apt-get install -y ansible
+RUN apt-add-repository -y ppa:ansible/ansible \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ansible \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
 
 # Install Ansible inventory file
 RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts


### PR DESCRIPTION
I rewrite following the layer rule, one RUN, one action.

For **Debian/Ubuntu**,  I add clean-up below:
```
&& rm -rf /var/lib/apt/lists/* \
&& rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
&& apt-get clean
```

For **Centos**, I have just "align" install and clean: 
```
RUN yum -y install <packages>; yum clean all
```

**Before**
```
REPOSITORY                     TAG                 IMAGE ID            SIZE
centos-7                       ansible             d6679028c8d8        477.7 MB
centos-6                       ansible             c5044c62f0e6        412.3 MB
ubuntu-14.04                   ansible             21c4c03a0711        347.2 MB
ubuntu-12.04                   ansible             4942aa95bdc8        327.1 MB
```
**After**
```
REPOSITORY                     TAG                 IMAGE ID            SIZE
centos-7                       ansible             7c941769382c        317.8 MB
centos-6                       ansible             92fc7d16654d        356.5 MB
ubuntu-14.04                   ansible             2a7122e84971        285.7 MB
ubuntu-12.04                   ansible             b4ba94102672        248.5 MB
```