### PR TITLE
Use the var jenkins_java_options to set extra Java options in the init file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This role will install the latest version of Jenkins by default (using the offic
     jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian-stable binary/
     jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key
 
+Extra Java options for the Jenkins launch command configured in the init file can be set with the var `jenkins_java_options`. This is set to a default value to disable the Jenkins 2.0 setup wizard:
+
+    jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
+
 ## Dependencies
 
   - geerlingguy.java

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins: []
 jenkins_url_prefix: ""
+jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,7 @@ jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin
+
+jenkins_init_changes:
+    - {OPTION: "JENKINS_ARGS", VALUE: "--prefix={{jenkins_url_prefix}}"}
+    - {OPTION: "JENKINS_JAVA_OPTIONS", VALUE: "{{jenkins_java_options}}"}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,5 +12,5 @@ jenkins_admin_username: admin
 jenkins_admin_password: admin
 
 jenkins_init_changes:
-    - {OPTION: "JENKINS_ARGS", VALUE: "--prefix={{jenkins_url_prefix}}"}
-    - {OPTION: "JENKINS_JAVA_OPTIONS", VALUE: "{{jenkins_java_options}}"}
+  - {option: "JENKINS_ARGS", value: "--prefix={{ jenkins_url_prefix }}"}
+  - {option: "JENKINS_JAVA_OPTIONS", value: "{{ jenkins_java_options }}"}

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -8,6 +8,15 @@
     state: present
   register: jenkins_init_prefix
 
+- name: Add Java options to Jenkins launch command
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    insertafter: '^JENKINS_JAVA_OPTIONS='
+    regexp: '^JENKINS_JAVA_OPTIONS=\"\$JENKINS_JAVA_OPTIONS '
+    line: 'JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS {{ jenkins_java_options }}"'
+    state: present
+  register: jenkins_init_prefix
+
 - name: Immediately restart Jenkins on init config changes.
   service: name=jenkins state=restarted
   when: jenkins_init_prefix.changed

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -1,20 +1,13 @@
 ---
-- name: Ensure URL prefix is present in Jenkins config.
+- name: Modify variables in init file
   lineinfile:
     dest: "{{ jenkins_init_file }}"
-    insertafter: '^JENKINS_ARGS='
-    regexp: '^JENKINS_ARGS=\"\$JENKINS_ARGS --prefix='
-    line: 'JENKINS_ARGS="$JENKINS_ARGS --prefix={{ jenkins_url_prefix }}"'
+    insertafter: '^{{ item.OPTION }}='
+    regexp: '^{{ item.OPTION}}=\"\${{ item.OPTION }} '
+    line: '{{ item.OPTION }}="${{ item.OPTION }} {{ item.VALUE }}"'
     state: present
-  register: jenkins_init_prefix
-
-- name: Add Java options to Jenkins launch command
-  lineinfile:
-    dest: "{{ jenkins_init_file }}"
-    insertafter: '^JENKINS_JAVA_OPTIONS='
-    regexp: '^JENKINS_JAVA_OPTIONS=\"\$JENKINS_JAVA_OPTIONS '
-    line: 'JENKINS_JAVA_OPTIONS="$JENKINS_JAVA_OPTIONS {{ jenkins_java_options }}"'
-    state: present
+  with_items:
+      "{{jenkins_init_changes}}"
   register: jenkins_init_prefix
 
 - name: Immediately restart Jenkins on init config changes.

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -2,12 +2,12 @@
 - name: Modify variables in init file
   lineinfile:
     dest: "{{ jenkins_init_file }}"
-    insertafter: '^{{ item.OPTION }}='
-    regexp: '^{{ item.OPTION}}=\"\${{ item.OPTION }} '
-    line: '{{ item.OPTION }}="${{ item.OPTION }} {{ item.VALUE }}"'
+    insertafter: '^{{ item.option }}='
+    regexp: '^{{ item.option}}=\"\${{ item.option }} '
+    line: '{{ item.option }}="${{ item.option }} {{ item.value }}"'
     state: present
   with_items:
-      "{{jenkins_init_changes}}"
+      "{{ jenkins_init_changes }}"
   register: jenkins_init_prefix
 
 - name: Immediately restart Jenkins on init config changes.


### PR DESCRIPTION
Opening this to address the issue https://github.com/geerlingguy/ansible-role-jenkins/issues/66