### PR TITLE
Plugins: Add password-file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The HTTP port for Jenkins' web interface.
 
 Default admin account credentials which will be created the first time Jenkins is installed.
 
+    jenkins_admin_password_file: ""
+
+Default admin password file which will be created the first time Jenkins is installed as /var/lib/jenkins/secrets/initialAdminPassword
+
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin
+jenkins_admin_password_file: ""
 
 jenkins_init_changes:
   - {option: "JENKINS_ARGS", value: "--prefix={{ jenkins_url_prefix }}"}

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,7 +23,10 @@
     mode: 0755
   when: jenkins_plugins_folder_create.changed
 
-- name: Install Jenkins plugins.
+- stat: path={{ jenkins_admin_password_file }}
+  register: adminpasswordfile
+
+- name: Install Jenkins plugins using password.
   command: >
     java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
     install-plugin {{ item }}
@@ -31,4 +34,16 @@
     --password {{ jenkins_admin_password }}
     creates=/var/lib/jenkins/plugins/{{ item }}.jpi
   with_items: "{{ jenkins_plugins }}"
+  when: jenkins_admin_password != ""
+  notify: restart jenkins
+
+- name: Install Jenkins plugins using password-file.
+  command: >
+    java -jar {{ jenkins_jar_location }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix | default('') }}/
+    install-plugin {{ item }}
+    --username {{ jenkins_admin_username }}
+    --password-file {{ jenkins_admin_password_file }}
+    creates=/var/lib/jenkins/plugins/{{ item }}.jpi
+  with_items: "{{ jenkins_plugins }}"
+  when: adminpasswordfile.stat.exists == True
   notify: restart jenkins


### PR DESCRIPTION
I suggest to add the possibility to use the password file as an argument of the jenkins-cli.

So I add a condition on the install-plugin task in order to apply with password or with password-file.

If the password and the password-file are both set, that's trigger twice the plugins installation. That's a bit ugly but the user have to choose.