### PR TITLE
Register independent vars on each install type

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -35,7 +35,8 @@
     src: basic-security.groovy
     dest: /var/lib/jenkins/init.groovy.d/basic-security.groovy
   register: jenkins_users_config
-  when: jenkins_install_package_deb.changed or jenkins_install_package_rh.changed
+  when: (jenkins_install_package_deb is defined and jenkins_install_package_deb.changed) or
+        (jenkins_install_package_rh is defined and jenkins_install_package_rh.changed)
 
 - name: Immediately restart Jenkins on http or user changes.
   service: name=jenkins state=restarted

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -35,7 +35,7 @@
     src: basic-security.groovy
     dest: /var/lib/jenkins/init.groovy.d/basic-security.groovy
   register: jenkins_users_config
-  when: jenkins_install_package.changed
+  when: jenkins_install_package_deb.changed or jenkins_install_package_rh.changed
 
 - name: Immediately restart Jenkins on http or user changes.
   service: name=jenkins state=restarted

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -15,4 +15,4 @@
 
 - name: Ensure Jenkins is installed.
   apt: name=jenkins state=present
-  register: jenkins_install_package
+  register: jenkins_install_package_deb

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -14,4 +14,4 @@
 
 - name: Ensure Jenkins is installed.
   yum: name=jenkins state=installed
-  register: jenkins_install_package
+  register: jenkins_install_package_rh


### PR DESCRIPTION
When jenkins install is called, both tasks are visited. And
it registers result of jenkins_install_package twice, causing
it to have a wrong value, and don't install jenkins users, causing
security to don't be configure and plugins to fail.

It's better to add different vars for each task, and trigger
the users install in case of some of the two changed.