### PR TITLE
Jenkins Home Directory Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The system hostname; usually `localhost` works fine. This will be used during setup to communicate with the running Jenkins instance via HTTP requests.
 
+    jenkins_home: /var/lib/jenkins
+
+The Jenkins home directory which, amongst others, is being used for storing artifacts, workspaces and plugins. This variable allows you to override the default `/var/lib/jenkins` location.
+
     jenkins_http_port: 8080
 
 The HTTP port for Jenkins' web interface.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
+jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Remove Jenkins security init scripts after first startup.
   file:
-    path: /var/lib/jenkins/init.groovy.d/basic-security.groovy
+    path: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
     state: absent
 
 # Update Jenkins and install configured plugins.

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -3,7 +3,7 @@
 # can be installed via CLI. See: https://gist.github.com/rowan-m/1026918
 - name: Create Jenkins updates folder.
   file:
-    path: /var/lib/jenkins/updates
+    path: "{{ jenkins_home }}/updates"
     owner: jenkins
     group: jenkins
     mode: 0755
@@ -12,12 +12,12 @@
 
 - name: Update Jenkins plugin data.
   shell: >
-    curl -L https://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > /var/lib/jenkins/updates/default.json
-    creates=/var/lib/jenkins/updates/default.json
+    curl -L https://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > "{{ jenkins_home }}/updates/default.json"
+    creates="{{ jenkins_home }}/updates/default.json"
 
 - name: Permissions for default.json updates info.
   file:
-    path: /var/lib/jenkins/updates/default.json
+    path: "{{ jenkins_home }}/updates/default.json"
     owner: jenkins
     group: jenkins
     mode: 0755
@@ -32,7 +32,7 @@
     install-plugin {{ item }}
     --username {{ jenkins_admin_username }}
     --password {{ jenkins_admin_password }}
-    creates=/var/lib/jenkins/plugins/{{ item }}.jpi
+    creates="{{ jenkins_home }}/plugins/{{ item }}.jpi"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_password != ""
   notify: restart jenkins
@@ -43,7 +43,7 @@
     install-plugin {{ item }}
     --username {{ jenkins_admin_username }}
     --password-file {{ jenkins_admin_password_file }}
-    creates=/var/lib/jenkins/plugins/{{ item }}.jpi
+    creates={{ jenkins_home }}/plugins/{{ item }}.jpi
   with_items: "{{ jenkins_plugins }}"
   when: adminpasswordfile.stat.exists == True
   notify: restart jenkins

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -10,6 +10,13 @@
       "{{ jenkins_init_changes }}"
   register: jenkins_init_prefix
 
+- name: Set the Jenkins home directory
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_HOME=.*'
+    line: 'JENKINS_HOME={{ jenkins_home }}'
+  register: jenkins_home_config
+
 - name: Immediately restart Jenkins on init config changes.
   service: name=jenkins state=restarted
   when: jenkins_init_prefix.changed
@@ -24,7 +31,7 @@
 
 - name: Create custom init scripts directory.
   file:
-    path: /var/lib/jenkins/init.groovy.d
+    path: "{{ jenkins_home }}/init.groovy.d"
     state: directory
     owner: jenkins
     group: jenkins
@@ -33,11 +40,11 @@
 - name: Configure Jenkins default users.
   template:
     src: basic-security.groovy
-    dest: /var/lib/jenkins/init.groovy.d/basic-security.groovy
+    dest: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
   register: jenkins_users_config
   when: (jenkins_install_package_deb is defined and jenkins_install_package_deb.changed) or
         (jenkins_install_package_rh is defined and jenkins_install_package_rh.changed)
 
 - name: Immediately restart Jenkins on http or user changes.
   service: name=jenkins state=restarted
-  when: jenkins_users_config.changed or jenkins_http_config.changed
+  when: jenkins_users_config.changed or jenkins_http_config.changed or jenkins_home_config.changed


### PR DESCRIPTION
Added support for specifying the Jenkins home directory. This allows users to store their artefacts in a preferred location.

The previously used ‘/var/lib/jenkins’ directory is used as the default value. All hardcoded path references have been updated to use the newly introduced {{ jenkins_home }} variable.