### PR TITLE
Jenkins tweaks and CentOS 7 install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,8 @@ script:
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm curl http://localhost:$http_port/$prefix'
 
 after_failure:
-  # Check what happened via journalctl
+  # Check what happened on systemd systems.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl status jenkins.service'
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm journalctl -xe'
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,8 @@ script:
 
 after_failure:
   # Check what happened on systemd systems.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl status jenkins.service'
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm journalctl -xe'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm systemctl -l status jenkins.service'
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm journalctl -xe --no-pager'
 
 after_success:
   # Clean up

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,34 @@
 sudo: required
 
 env:
-  - distribution: centos
-    version: 6
-    init: /sbin/init
-    run_opts: ""
-    site: test.yml
-    prefix: ''
-    http_port: 8080
-  - distribution: centos
-    version: 6
-    init: /sbin/init
-    run_opts: ""
-    site: test-jenkins-version.yml
-    prefix: ''
-    http_port: 8080
   # - distribution: centos
-  #   version: 7
-  #   init: /usr/lib/systemd/systemd
-  #   run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  #   version: 6
+  #   init: /sbin/init
+  #   run_opts: ""
   #   site: test.yml
   #   prefix: ''
   #   http_port: 8080
+  # - distribution: centos
+  #   version: 6
+  #   init: /sbin/init
+  #   run_opts: ""
+  #   site: test-jenkins-version.yml
+  #   prefix: ''
+  #   http_port: 8080
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    site: test-jenkins-version.yml
+    prefix: ''
+    http_port: 8080
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    site: test.yml
+    prefix: ''
+    http_port: 8080
   - distribution: ubuntu
     version: 14.04
     init: /sbin/init

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 Jenkins plugins to be installed automatically during provisioning. (_Note_: This feature is currently undergoing some changes due to the `jenkins-cli` authentication changes in Jenkins 2.0, and may not work as expected.)
 
     jenkins_version: "1.644"
-    jenkins_pkg_url: "https://www.example.com/"
+    jenkins_pkg_url: "http://www.example.com/"
 
 (Optional) Then Jenkins version can be pinned to any version available on `http://pkg.jenkins-ci.org/debian/` (Debian/Ubuntu) or `http://pkg.jenkins-ci.org/redhat/` (RHEL/CentOS). If the Jenkins version you need is not available in the default package URLs, you can override the URL with your own; set `jenkins_pkg_url` (_Note_: the role depends on the same naming convention that `http://pkg.jenkins-ci.org/` uses).
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,10 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 
 Jenkins plugins to be installed automatically during provisioning. (_Note_: This feature is currently undergoing some changes due to the `jenkins-cli` authentication changes in Jenkins 2.0, and may not work as expected.)
 
-    jenkins_version: 1.644
+    jenkins_version: "1.644"
+    jenkins_pkg_url: "https://www.example.com/"
 
-Jenkins version can be pinned to any version available on http://pkg.jenkins-ci.org/debian/ or http://pkg.jenkins-ci.org/redhat/ (depending on the {{ ansible_os_family }}).
-
-    jenkins_pkg_url: http://example.com/
-
-If the Jenkins version you need is not available in http://pkg.jenkins-ci.org/debian/ or http://pkg.jenkins-ci.org/redhat/, the URL can be customized by setting jenkins_pkg_url (_Note_: the role depends on the same naming convention that http://pkg.jenkins-ci.org/ uses).
+(Optional) Then Jenkins version can be pinned to any version available on `http://pkg.jenkins-ci.org/debian/` (Debian/Ubuntu) or `http://pkg.jenkins-ci.org/redhat/` (RHEL/CentOS). If the Jenkins version you need is not available in the default package URLs, you can override the URL with your own; set `jenkins_pkg_url` (_Note_: the role depends on the same naming convention that `http://pkg.jenkins-ci.org/` uses).
 
     jenkins_url_prefix: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+# Optional method of pinning a specific version of Jenkins and/or overriding the
+# default Jenkins packaging URL.
+# jenkins_version: "1.644"
+# jenkins_pkg_url: "https://www.example.com/"
+
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,8 +1,11 @@
 ---
 - name: Ensure dependencies are installed.
   apt:
-    pkg: curl
+    pkg: "{{ item }}"
     state: installed
+  with_items:
+    - curl
+    - apt-transport-https
 
 - name: Add Jenkins apt repository key.
   apt_key:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,11 +1,8 @@
 ---
 - name: Ensure dependencies are installed.
   apt:
-    pkg: "{{ item }}"
+    pkg: curl
     state: installed
-  with_items:
-    - curl
-    - apt-transport-https
 
 - name: Add Jenkins apt repository key.
   apt_key:

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -1,6 +1,6 @@
 FROM centos:7
 MAINTAINER Jeff Geerling
-ENV container docker
+ENV container=docker
 
 # Install systemd -- See https://hub.docker.com/_/centos/
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -1,16 +1,15 @@
 FROM centos:7
 MAINTAINER Jeff Geerling
+ENV container docker
 
 # Install systemd -- See https://hub.docker.com/_/centos/
-RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
-RUN yum -y update; yum clean all; \
-(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*; \
-rm -f /etc/systemd/system/*.wants/*; \
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
 rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install Ansible

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -12,9 +12,9 @@ rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
 rm -f /lib/systemd/system/basic.target.wants/*;\
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
-# Install Ansible
+# Install Ansible and other requirements.
 RUN yum makecache fast \
- && yum -y install deltarpm epel-release \
+ && yum -y install deltarpm epel-release initscripts \
  && yum -y update \
  && yum -y install \
       ansible \

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
-__jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian binary/
-__jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
-__jenkins_pkg_url: http://pkg.jenkins-ci.org/debian/binary
+__jenkins_repo_url: deb https://pkg.jenkins.io/debian binary/
+__jenkins_repo_key_url: https://pkg.jenkins.io/debian/jenkins.io.key
+__jenkins_pkg_url: https://pkg.jenkins.io/debian/binary/
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,6 @@
 ---
-__jenkins_repo_url: deb https://pkg.jenkins.io/debian binary/
-__jenkins_repo_key_url: https://pkg.jenkins.io/debian/jenkins.io.key
-__jenkins_pkg_url: https://pkg.jenkins.io/debian/binary/
+__jenkins_repo_url: deb http://pkg.jenkins.io/debian binary/
+__jenkins_repo_key_url: http://pkg.jenkins.io/debian/jenkins.io.key
+__jenkins_pkg_url: http://pkg.jenkins.io/debian/binary/
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
-__jenkins_repo_url: http://pkg.jenkins-ci.org/redhat/jenkins.repo
-__jenkins_repo_key_url: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
-__jenkins_pkg_url: http://pkg.jenkins-ci.org/redhat
+__jenkins_repo_url: https://pkg.jenkins.io/redhat/jenkins.repo
+__jenkins_repo_key_url: https://pkg.jenkins.io/redhat/jenkins.io.key
+__jenkins_pkg_url: https://pkg.jenkins.io/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,6 @@
 ---
-__jenkins_repo_url: https://pkg.jenkins.io/redhat/jenkins.repo
-__jenkins_repo_key_url: https://pkg.jenkins.io/redhat/jenkins.io.key
-__jenkins_pkg_url: https://pkg.jenkins.io/redhat
+__jenkins_repo_url: http://pkg.jenkins.io/redhat/jenkins.repo
+__jenkins_repo_key_url: http://pkg.jenkins.io/redhat/jenkins.io.key
+__jenkins_pkg_url: http://pkg.jenkins.io/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT


### PR DESCRIPTION
I was getting the following error on CentOS 7:

```
TASK [role_under_test : Immediately restart Jenkins on init config changes.] ***
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Job for jenkins.service failed because the control process exited with error code. See \"systemctl status jenkins.service\" and \"journalctl -xe\" for details.\n"}
 [ERROR]: Could not create retry file '/etc/ansible/roles/role_under_test/tests
/test-jenkins-version.retry'. The error was: [Errno 30] Read-only file system:
'/etc/ansible/roles/role_under_test/tests/test-jenkins-version.retry'
```

After doing some digging (debugging with `systemctl -l status jenkins.service` and `journalctl -xe --no-pager`), I found that the true error was:

```
Aug 10 05:06:32 d0e401af0f09 systemd[1]: Starting LSB: Jenkins Continuous Integration Server...
Aug 10 05:06:32 d0e401af0f09 jenkins[811]: /etc/rc.d/init.d/jenkins: line 51: /etc/init.d/functions: No such file or directory
Aug 10 05:06:32 d0e401af0f09 systemd[1]: jenkins.service: control process exited, code=exited status=1
Aug 10 05:06:32 d0e401af0f09 systemd[1]: Failed to start LSB: Jenkins Continuous Integration Server.
Aug 10 05:06:32 d0e401af0f09 systemd[1]: Unit jenkins.service entered failed state.
Aug 10 05:06:32 d0e401af0f09 systemd[1]: jenkins.service failed.
```

Specifically, the line:

```
/etc/rc.d/init.d/jenkins: line 51: /etc/init.d/functions: No such file or directory
```

Searching around, I found this issue (https://github.com/docker-library/official-images/issues/339), which suggested installing the `initscripts` package on the CentOS Docker image, so I tried that. After installing it, the Travis build succeeds!