### PR TITLE
Allow plugin install to work using pinned versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,7 @@
 sudo: required
 
 env:
-  # - distribution: centos
-  #   version: 6
-  #   init: /sbin/init
-  #   run_opts: ""
-  #   site: test.yml
-  #   prefix: ''
-  #   http_port: 8080
-  # - distribution: centos
-  #   version: 6
-  #   init: /sbin/init
-  #   run_opts: ""
-  #   site: test-jenkins-version.yml
-  #   prefix: ''
-  #   http_port: 8080
-  - distribution: centos
-    version: 7
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    site: test-jenkins-version.yml
-    prefix: ''
-    http_port: 8080
+  # tests/test.yml
   - distribution: centos
     version: 7
     init: /usr/lib/systemd/systemd
@@ -45,10 +25,11 @@ env:
     prefix: ''
     http_port: 8080
 
-  - distribution: ubuntu
-    version: 14.04
-    init: /sbin/init
-    run_opts: ""
+  # tests/test-http-port.yml
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
     site: test-http-port.yml
     prefix: ''
     http_port: 8081
@@ -56,15 +37,55 @@ env:
     version: 14.04
     init: /sbin/init
     run_opts: ""
+    site: test-http-port.yml
+    prefix: ''
+    http_port: 8081
+
+  # tests/test-prefix.yml
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    site: test-prefix.yml
+    prefix: ''
+    http_port: 8080
+  - distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
     site: test-prefix.yml
     prefix: jenkins
+    http_port: 8080
+
+  # tests/test-jenkins-version.yml
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    site: test-jenkins-version.yml
+    prefix: ''
+    http_port: 8080
+  - distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
+    site: test-jenkins-version.yml
+    prefix: ''
+    http_port: 8080
+
+  # tests/test-plugins.yml
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    site: test-plugins.yml
+    prefix: ''
     http_port: 8080
   - distribution: ubuntu
     version: 14.04
     init: /sbin/init
     run_opts: ""
     site: test-plugins.yml
-    site: test-jenkins-version.yml
     prefix: ''
     http_port: 8080
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,6 @@ env:
     http_port: 8080
 
   # tests/test-http-port.yml
-  - distribution: centos
-    version: 7
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    site: test-http-port.yml
-    prefix: ''
-    http_port: 8081
   - distribution: ubuntu
     version: 14.04
     init: /sbin/init
@@ -42,13 +35,6 @@ env:
     http_port: 8081
 
   # tests/test-prefix.yml
-  - distribution: centos
-    version: 7
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    site: test-prefix.yml
-    prefix: ''
-    http_port: 8080
   - distribution: ubuntu
     version: 14.04
     init: /sbin/init
@@ -74,13 +60,6 @@ env:
     http_port: 8080
 
   # tests/test-plugins.yml
-  - distribution: centos
-    version: 7
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    site: test-plugins.yml
-    prefix: ''
-    http_port: 8080
   - distribution: ubuntu
     version: 14.04
     init: /sbin/init
@@ -90,13 +69,6 @@ env:
     http_port: 8080
 
   # tests/test-plugins-with-pinning.yml
-  - distribution: centos
-    version: 7
-    init: /usr/lib/systemd/systemd
-    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
-    site: test-plugins-with-pinning.yml
-    prefix: ''
-    http_port: 8080
   - distribution: ubuntu
     version: 14.04
     init: /sbin/init

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,22 @@ env:
     prefix: ''
     http_port: 8080
 
+  # tests/test-plugins-with-pinning.yml
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    site: test-plugins-with-pinning.yml
+    prefix: ''
+    http_port: 8080
+  - distribution: ubuntu
+    version: 14.04
+    init: /sbin/init
+    run_opts: ""
+    site: test-plugins-with-pinning.yml
+    prefix: ''
+    http_port: 8080
+
 services:
   - docker
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,9 @@
 ---
 - name: restart jenkins
   service: name=jenkins state=restarted
+
+- name: configure default users
+  template:
+    src: basic-security.groovy
+    dest: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
+  register: jenkins_users_config

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -11,9 +11,9 @@
   register: jenkins_plugins_folder_create
 
 - name: Update Jenkins plugin data.
-  shell: >
-    curl -L https://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > "{{ jenkins_home }}/updates/default.json"
-    creates="{{ jenkins_home }}/updates/default.json"
+  shell: curl -L https://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > "{{ jenkins_home }}/updates/default.json"
+  args:
+    creates: "{{ jenkins_home }}/updates/default.json"
 
 - name: Permissions for default.json updates info.
   file:
@@ -23,7 +23,9 @@
     mode: 0755
   when: jenkins_plugins_folder_create.changed
 
-- stat: path={{ jenkins_admin_password_file }}
+- name: Check if we're using a password file for authentication
+  stat:
+    path: "{{ jenkins_admin_password_file }}"
   register: adminpasswordfile
 
 - name: Install Jenkins plugins using password.

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -37,14 +37,11 @@
     group: jenkins
     mode: 0775
 
-- name: Configure Jenkins default users.
-  template:
-    src: basic-security.groovy
-    dest: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
-  register: jenkins_users_config
-  when: (jenkins_install_package_deb is defined and jenkins_install_package_deb.changed) or
-        (jenkins_install_package_rh is defined and jenkins_install_package_rh.changed)
+- name: Trigger handlers immediately in case Jenkins was installed
+  meta: flush_handlers
 
 - name: Immediately restart Jenkins on http or user changes.
   service: name=jenkins state=restarted
-  when: jenkins_users_config.changed or jenkins_http_config.changed or jenkins_home_config.changed
+  when: (jenkins_users_config is defined and jenkins_users_config.changed) or
+        (jenkins_http_config is defined and jenkins_http_config.changed) or
+        (jenkins_home_config is defined and jenkins_home_config.changed)

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -31,12 +31,13 @@
     deb: "/tmp/jenkins.deb"
     state: installed
   when: specific_version.stat.exists
+  notify: configure default users
 
 - name: Validate Jenkins is installed and register package name.
   apt:
     name: jenkins
     state: present
-  register: jenkins_install_package_deb
+  notify: configure default users
 
 - name: Install Jenkins from repository.
   apt:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -30,12 +30,14 @@
     name: "/tmp/jenkins.rpm"
     state: installed
   when: specific_version.stat.exists
+  notify: configure default users
 
 - name: Validate Jenkins is installed and register package name.
   yum:
     name: jenkins
     state: present
-  register: jenkins_install_package_rh
+  when: not specific_version.stat.exists
+  notify: configure default users
 
 - name: Install Jenkins from repository.
   yum:

--- a/tests/test-plugins-with-pinning.yml
+++ b/tests/test-plugins-with-pinning.yml
@@ -1,6 +1,8 @@
 - hosts: localhost
   vars:
-    jenkins_version: 1.644
+    jenkins_version: 2.14
+    jenkins_plugins:
+      - ant
 
   roles:
     - geerlingguy.java


### PR DESCRIPTION
When we added the ability to pin versions, it broke the ability to install
plugins since it doesn't register the variables correctly to trigger the
changes introduced in #72.

Unfortunately, the fix of adding a register to the pinned version package
installation module (yum / apt) execution re-introduces the exact same issue
that #72 is attempting to resolve.

So, in order to work around that limitation, I've moved the deployment of
the authentication groovy script to a handler, and then notified that handler
from both the application installation routines.

There is also the addition of a meta module to flush the handlers so that
the groovy script is installed immediately, and thereby registering the
correct values to trigger a restart of Jenkins if necessary.

Resolves #70