### PR TITLE
Feature/ Installing jenkins plugins behind proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ jenkins_admin_token_file: ""
 jenkins_process_user: jenkins
 jenkins_process_group: "{{ jenkins_process_user }}"
 
+jenkins_http_proxy: "{{ ansible_env.http_proxy | default('') or ansible_env.HTTP_PROXY | default('') }}"
+jenkins_no_proxy: "{{ ansible_env.no_proxy | default('') or ansible_env.NO_PROXY | default('') }}"
+
 jenkins_init_changes:
   - option: "JENKINS_ARGS"
     value: "--prefix={{ jenkins_url_prefix }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,3 +10,9 @@
     group: "{{ jenkins_process_group }}"
     mode: 0775
   register: jenkins_users_config
+
+- name: configure proxy
+  template:
+    src: basic-proxy.groovy
+    dest: "{{ jenkins_home }}/init.groovy.d/basic-proxy.groovy"
+  register: jenkins_proxy_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,5 +56,10 @@
     path: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
     state: absent
 
+- name: Remove Jenkins proxy init scripts after first startup.
+  file:
+    path: "{{ jenkins_home }}/init.groovy.d/basic-proxy.groovy"
+    state: absent
+
 # Update Jenkins and install configured plugins.
 - include: plugins.yml

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -52,4 +52,5 @@
   service: name=jenkins state=restarted
   when: (jenkins_users_config is defined and jenkins_users_config.changed) or
         (jenkins_http_config is defined and jenkins_http_config.changed) or
-        (jenkins_home_config is defined and jenkins_home_config.changed)
+        (jenkins_home_config is defined and jenkins_home_config.changed) or
+        (jenkins_proxy_config is defined and jenkins_proxy_config.changed)

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -35,10 +35,14 @@
     deb: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
     state: installed
   when: jenkins_version is defined and specific_version.stat.exists
-  notify: configure default users
+  notify:
+    - configure default users
+    - configure proxy
 
 - name: Ensure Jenkins is installed.
   apt:
     name: jenkins
     state: "{{ jenkins_package_state }}"
-  notify: configure default users
+  notify:
+    - configure default users
+    - configure proxy

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -35,10 +35,14 @@
     name: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     state: installed
   when: jenkins_version is defined and specific_version.stat.exists
-  notify: configure default users
+  notify:
+    - configure default users
+    - configure proxy
 
 - name: Ensure Jenkins is installed.
   package:
     name: jenkins
     state: "{{ jenkins_package_state }}"
-  notify: configure default users
+  notify:
+    - configure default users
+    - configure proxy

--- a/templates/basic-proxy.groovy
+++ b/templates/basic-proxy.groovy
@@ -1,0 +1,27 @@
+#!groovy
+import jenkins.model.*
+
+def instance = Jenkins.getInstance()
+
+println "set up proxy for installing plugins.."
+
+final String http_proxy = '{{ jenkins_http_proxy }}'
+final String no_proxy = '{{ jenkins_no_proxy }}'
+
+def regex_proxy = /^http:\/\/(([^:]+):?(\S+)?@)?([^:]+)(:(\d+))?\/?$/
+def matcher = ( http_proxy =~ regex_proxy )
+
+if (matcher.matches()) {
+
+  println(matcher[0])
+
+  def http_proxy_user = matcher[0][2] ? matcher[0][2] : ''
+  def http_proxy_password = matcher[0][3] ? matcher[0][3] : ''
+  def http_proxy_host = matcher[0][4]
+  def http_proxy_port = matcher[0][6]? matcher[0][6].toInteger() : 80
+
+  def pc = new hudson.ProxyConfiguration(http_proxy_host, http_proxy_port, http_proxy_user, http_proxy_password, no_proxy)
+  instance.proxy = pc
+  instance.save()
+
+}


### PR DESCRIPTION
Implementation of #28 

Update jenkins proxy configuration temporarily from ansible remote and install plugins.

This allow to user who is behind proxy can install plugins.
