### PR TITLE
adds ability to override jenkins update url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Default admin password file which will be created the first time Jenkins is inst
 
     jenkins_jar_location: /opt/jenkins-cli.jar
 
+The Jenkins Update URL to use. This is useful when one wants to install plugins from an alternate url
+such as the experimental update center, default is normal update center https://updates.jenkins-ci.org/update-center.json:
+
+    jenkins_update_url: "http://updates.jenkins-ci.org/experimental/update-center.json"
+
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.
 
     jenkins_plugins: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
+jenkins_update_url: "https://updates.jenkins-ci.org/update-center.json"
 jenkins_plugins: []
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -11,7 +11,7 @@
   register: jenkins_plugins_folder_create
 
 - name: Update Jenkins plugin data.
-  shell: curl -L https://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > "{{ jenkins_home }}/updates/default.json"
+  shell: curl -L {{ jenkins_update_url }} | sed '1d;$d' > "{{ jenkins_home }}/updates/default.json"
   args:
     creates: "{{ jenkins_home }}/updates/default.json"
 


### PR DESCRIPTION
provides a new variable "jenkins_update_url" that can allow the user to use the experiemental update URL. This allows users to install the BlueOcean CI view.
