### PR TITLE
Removing negation that prevents initial admin user creation

### DIFF
--- a/templates/basic-security.groovy
+++ b/templates/basic-security.groovy
@@ -6,7 +6,7 @@ def instance = Jenkins.getInstance()
 
 println "--> Checking if security has been set already"
 
-if (!instance.isUseSecurity()) {
+if (instance.isUseSecurity()) {
     println "--> creating local user 'admin'"
 
     def hudsonRealm = new HudsonPrivateSecurityRealm(false)


### PR DESCRIPTION
As discussed in Issue #79, several users including myself have found this negation to be preventing the initial creation of the specified admin user when applying this role.  Removing the negation fixed this problem.  If this negation is necessary or removing it breaks functionality elsewhere, then please feel free to close out this PR.