### PR TITLE
Add support for setting a public SSH key for the admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Default admin account credentials which will be created the first time Jenkins i
 
 Default admin password file which will be created the first time Jenkins is installed as /var/lib/jenkins/secrets/initialAdminPassword
 
+    jenkins_admin_pubkey: ""
+
+Default public SSH authorised key which will be added to the admin user the first time Jenkins is installed. Useful for authenticating against the Jenkins CLI.
+
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 jenkins_admin_username: admin
 jenkins_admin_password: admin
 jenkins_admin_password_file: ""
+jenkins_admin_pubkey: ""
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"

--- a/templates/basic-security.groovy
+++ b/templates/basic-security.groovy
@@ -1,6 +1,8 @@
 #!groovy
 import hudson.security.*
 import jenkins.model.*
+import hudson.model.*
+import org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl
 
 def instance = Jenkins.getInstance()
 
@@ -16,4 +18,7 @@ if (!instance.isUseSecurity()) {
     def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
     instance.setAuthorizationStrategy(strategy)
     instance.save()
+
+    def admin = User.get('{{ jenkins_admin_username }}')
+    admin.addProperty(new UserPropertyImpl('{{ jenkins_admin_pubkey }}'))
 }


### PR DESCRIPTION
According to https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+CLI "if your Jenkins requires authentication, you should set up public key authentication". This is particularly true for certain aspects of Jenkins CLI, like creating a job, which will awkwardly fail.

Adding this option helps with further automation of Jenkins. It should be kept in mind that a restart seems to be required for changes to apply.