### PR TITLE
Added listen address config variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The Jenkins home directory which, amongst others, is being used for storing arti
 
 The HTTP port for Jenkins' web interface.
 
+    jenkins_http_listen_address: "0.0.0.0"
+
+The IP address Jenkins listens on for HTTP requests.
+
     jenkins_admin_username: admin
     jenkins_admin_password: admin
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
+jenkins_http_listen_address: "0.0.0.0"
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_plugins: []

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -29,6 +29,14 @@
     line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
   register: jenkins_http_config
 
+- name: Set Listen Address in Jenkins config.
+  lineinfile:
+    backrefs: yes
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_http_listen_address_param }}='
+    line: '{{ jenkins_http_listen_address_param }}="{{ jenkins_http_listen_address }}"'
+  register: jenkins_http_listen_address_config
+
 - name: Create custom init scripts directory.
   file:
     path: "{{ jenkins_home }}/init.groovy.d"
@@ -44,4 +52,5 @@
   service: name=jenkins state=restarted
   when: (jenkins_users_config is defined and jenkins_users_config.changed) or
         (jenkins_http_config is defined and jenkins_http_config.changed) or
-        (jenkins_home_config is defined and jenkins_home_config.changed)
+        (jenkins_home_config is defined and jenkins_home_config.changed) or
+        (jenkins_http_listen_address_config is defined and jenkins_http_listen_address_config.changed)

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,5 @@ __jenkins_repo_key_url: http://pkg.jenkins.io/debian/jenkins.io.key
 __jenkins_pkg_url: http://pkg.jenkins.io/debian/binary/
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT
+jenkins_http_listen_address_param: JENKINS_LISTEN_ADDRESS
 jenkins_java_options_env_var: JAVA_ARGS

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,4 +4,5 @@ __jenkins_repo_key_url: http://pkg.jenkins.io/redhat/jenkins.io.key
 __jenkins_pkg_url: http://pkg.jenkins.io/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT
+jenkins_http_listen_address_param: JENKINS_LISTEN_ADDRESS
 jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS


### PR DESCRIPTION
- Added jenkins_http_listen_address role variable.  This allows you to change
  the default listen address (0.0.0.0) to a different address, such as 127.0.0.1.
- This works well in conjunction with geerlingguy.nginx role for proxying to
  jenkins.