### PR TITLE
Make Jenkins system user configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,14 @@ env:
     prefix: ''
     http_port: 8080
 
+  # tests/test-system-user.yml
+  - distro: ubuntu1404
+    init: /sbin/init
+    run_opts: ""
+    site: test-system-user.yml
+    prefix: ''
+    http_port: 8080
+
 before_install:
   # Pull container
   - 'docker pull geerlingguy/docker-${distro}-ansible:latest'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
+jenkins_user: jenkins
+jenkins_group: "{{ jenkins_user }}"
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -4,8 +4,8 @@
 - name: Create Jenkins updates folder.
   file:
     path: "{{ jenkins_home }}/updates"
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
     mode: 0755
     state: directory
   register: jenkins_plugins_folder_create
@@ -18,8 +18,8 @@
 - name: Permissions for default.json updates info.
   file:
     path: "{{ jenkins_home }}/updates/default.json"
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
     mode: 0755
   when: jenkins_plugins_folder_create.changed
 

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -17,6 +17,14 @@
     line: 'JENKINS_HOME={{ jenkins_home }}'
   register: jenkins_home_config
 
+- name: Set the Jenkins system user
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_USER=.*'
+    line: 'JENKINS_USER={{ jenkins_user }}'
+    state: present
+  register: jenkins_user_config
+
 - name: Immediately restart Jenkins on init config changes.
   service: name=jenkins state=restarted
   when: jenkins_init_prefix.changed
@@ -33,8 +41,8 @@
   file:
     path: "{{ jenkins_home }}/init.groovy.d"
     state: directory
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
     mode: 0775
 
 - name: Trigger handlers immediately in case Jenkins was installed
@@ -44,4 +52,5 @@
   service: name=jenkins state=restarted
   when: (jenkins_users_config is defined and jenkins_users_config.changed) or
         (jenkins_http_config is defined and jenkins_http_config.changed) or
-        (jenkins_home_config is defined and jenkins_home_config.changed)
+        (jenkins_home_config is defined and jenkins_home_config.changed) or
+        (jenkins_user_config is defined and jenkins_user_config.changed)

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,4 +1,15 @@
 ---
+- name: Create jenkins group
+  group:
+    state: present
+    name: "{{ jenkins_group }}"
+
+- name: Create jenkins user
+  user:
+    state: present
+    name: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+
 - name: Ensure dependencies are installed.
   apt:
     pkg: curl
@@ -44,3 +55,27 @@
     name: jenkins
     state: installed
   when: jenkins_version is undefined
+
+- name: Ensure jenkins home belongs to the jenkins user
+  file:
+    path: "{{ jenkins_home }}"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    state: directory
+    recurse: yes
+
+- name: Ensure log directory belongs to the jenkins user
+  file:
+    path: /var/log/jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    state: directory
+    recurse: yes
+
+- name: Ensure cache directory belongs to the jenkins user
+  file:
+    path: /var/cache/jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    state: directory
+    recurse: yes

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,4 +1,15 @@
 ---
+- name: Create jenkins group
+  group:
+    state: present
+    name: "{{ jenkins_group }}"
+
+- name: Create jenkins user
+  user:
+    state: present
+    name: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+
 - name: Ensure dependencies are installed.
   package:
     name: 
@@ -46,3 +57,27 @@
     name: jenkins
     state: installed
   when: jenkins_version is undefined
+
+- name: Ensure jenkins home belongs to the jenkins user
+  file:
+    path: "{{ jenkins_home }}"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    state: directory
+    recurse: yes
+
+- name: Ensure log directory belongs to the jenkins user
+  file:
+    path: /var/log/jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    state: directory
+    recurse: yes
+
+- name: Ensure cache directory belongs to the jenkins user
+  file:
+    path: /var/cache/jenkins
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    state: directory
+    recurse: yes

--- a/tests/test-system-user.yml
+++ b/tests/test-system-user.yml
@@ -1,0 +1,9 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_user: testuser
+
+  roles:
+    - geerlingguy.java
+    - role_under_test


### PR DESCRIPTION
Hi,
In our environment, we want Jenkins to run as a specific system user. So I added role variables to configure the user and group that owns the process and files.