### PR TITLE
Versioned .deb file name

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -20,19 +20,14 @@
 - name: Download specific Jenkins version.
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
-    dest: "/tmp/jenkins.deb"
+    dest: "/tmp/jenkins_{{ jenkins_version }}.deb"
   when: jenkins_version is defined
-
-- name: Check if we downloaded a specific version of Jenkins.
-  stat:
-    path: "/tmp/jenkins.deb"
-  register: specific_version
 
 - name: Install our specific version of Jenkins.
   apt:
-    deb: "/tmp/jenkins.deb"
+    deb: "/tmp/jenkins_{{ jenkins_version }}.deb"
     state: installed
-  when: specific_version.stat.exists
+  when: jenkins_version is defined
   notify: configure default users
 
 - name: Validate Jenkins is installed and register package name.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -20,26 +20,20 @@
 - name: Download specific Jenkins version.
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
-    dest: "/tmp/jenkins.rpm"
+    dest: "/tmp/jenkins_{{ jenkins_version }}.rpm"
   when: jenkins_version is defined
-
-- name: Check if we downloaded a specific version of Jenkins.
-  stat:
-    path: "/tmp/jenkins.rpm"
-  register: specific_version
 
 - name: Install our specific version of Jenkins.
   package:
-    name: "/tmp/jenkins.rpm"
+    name: "/tmp/jenkins_{{ jenkins_version }}.rpm"
     state: installed
-  when: specific_version.stat.exists
+  when: jenkins_version is defined
   notify: configure default users
 
 - name: Validate Jenkins is installed and register package name.
   package:
     name: jenkins
     state: present
-  when: not specific_version.stat.exists
   notify: configure default users
 
 - name: Install Jenkins from repository.


### PR DESCRIPTION
This fixes the case where re-running the role with "jenkins_version" set to a
different version would not download the .deb.