### PR TITLE
Ensure that jenkins_home exists

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -29,6 +29,14 @@
     line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
   register: jenkins_http_config
 
+- name: Ensure jenkins_home {{ jenkins_home }} exists
+  file:
+    path: "{{ jenkins_home }}"
+    state: directory
+    owner: jenkins
+    group: jenkins
+    mode: u+rwx
+
 - name: Create custom init scripts directory.
   file:
     path: "{{ jenkins_home }}/init.groovy.d"


### PR DESCRIPTION
This is needed when custom path is used, as correct owner/group cannot
be set before jenkins package (and jenkins user creation) is done.

It is difficult to handle elsewhere than in your role as it is not possible to assign the right ownership and permission before jenkins is installed. I use a minimalist behavior on permission setting, with just owner permission check (u+rwx).
