### PR TITLE
jenkins_init_changes · allow to reset value

### DIFF
--- a/tasks/jenkins_init_changes.yml
+++ b/tasks/jenkins_init_changes.yml
@@ -1,0 +1,23 @@
+---
+- name: Modify variables in init file (append)
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    insertafter: '^{{ item.option }}='
+    regexp: '^{{ item.option}}=\"\${{ item.option }} '
+    line: '{{ item.option }}="${{ item.option }} {{ item.value }}"'
+    state: present
+  when: not item.reset | default(False)
+  register: jenkins_init_prefix_append
+
+- name: Modify variables in init file (reset)
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    insertafter: '^{{ item.option }}='
+    regexp: '^{{ item.option}}='
+    line: '{{ item.option }}="{{ item.value }}"'
+    state: present
+  when: item.reset | default(False)
+  register: jenkins_init_prefix_modify
+
+- name: update jenkins_init_prefix
+  set_fact: { jenkins_init_prefix: "{{ hostvars[inventory_hostname]['jenkins_init_prefix'] | default(False) or jenkins_init_prefix_modify.changed or jenkins_init_prefix_append.changed }}" }

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -1,14 +1,7 @@
 ---
-- name: Modify variables in init file
-  lineinfile:
-    dest: "{{ jenkins_init_file }}"
-    insertafter: '^{{ item.option }}='
-    regexp: '^{{ item.option}}=\"\${{ item.option }} '
-    line: '{{ item.option }}="${{ item.option }} {{ item.value }}"'
-    state: present
+- include: jenkins_init_changes.yml
   with_items:
-      "{{ jenkins_init_changes }}"
-  register: jenkins_init_prefix
+    "{{ jenkins_init_changes }}"
 
 - name: Set the Jenkins home directory
   lineinfile:
@@ -19,7 +12,7 @@
 
 - name: Immediately restart Jenkins on init config changes.
   service: name=jenkins state=restarted
-  when: jenkins_init_prefix.changed
+  when: jenkins_init_prefix
 
 - name: Set HTTP port in Jenkins config.
   lineinfile:


### PR DESCRIPTION
jenkins_init_changes currently only allow to append new value to service configuration file. It breaks, for example **JENKINS_JAVA_CMD** as it adds the following line:

```
JENKINS_JAVA_CMD="$JENKINS_JAVA_CMD value"
```

It expands to **_value** (first character is a whitespace). As this value is not trimmed when java command is searched, the setting is not applied.

My proposal adds a new parameter reset (default false, to be compatible with the current behavior) that allows to handle my use-case.

New format for jenkins_init_changes:
```
jenkins_init_changes:
  - option: OPTION
    value: myvalue
    reset: yes # optional
```