### PR TITLE
Removes get_url WARNING

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,10 +32,10 @@
 - name: Ensure Jenkins is started and runs on startup.
   service: name=jenkins state=started enabled=yes
 
-- name: Wait for Jenkins to start up before proceeding.
-  shell: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
-  register: result
-  until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
+- name: Wait for Jenkins port.
+  wait_for:
+    host: "{{ jenkins_hostname }}"
+    port: "{{ jenkins_http_port }}"
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false


### PR DESCRIPTION
The usage of curl triggers a warning
"[WARNING]: Consider using get_url or uri module rather than running curl"

This removes the warning.