### PR TITLE
Trailing slash removed from jenkins_pkg_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 Jenkins plugins to be installed automatically during provisioning. (_Note_: This feature is currently undergoing some changes due to the `jenkins-cli` authentication changes in Jenkins 2.0, and may not work as expected.)
 
     jenkins_version: "1.644"
-    jenkins_pkg_url: "http://www.example.com/"
+    jenkins_pkg_url: "http://www.example.com"
 
 (Optional) Then Jenkins version can be pinned to any version available on `http://pkg.jenkins-ci.org/debian/` (Debian/Ubuntu) or `http://pkg.jenkins-ci.org/redhat/` (RHEL/CentOS). If the Jenkins version you need is not available in the default package URLs, you can override the URL with your own; set `jenkins_pkg_url` (_Note_: the role depends on the same naming convention that `http://pkg.jenkins-ci.org/` uses).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # Optional method of pinning a specific version of Jenkins and/or overriding the
 # default Jenkins packaging URL.
 # jenkins_version: "1.644"
-# jenkins_pkg_url: "https://www.example.com/"
+# jenkins_pkg_url: "https://www.example.com"
 
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,7 +1,7 @@
 ---
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian binary/
 __jenkins_repo_key_url: https://pkg.jenkins.io/debian/jenkins.io.key
-__jenkins_pkg_url: https://pkg.jenkins.io/debian/binary/
+__jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT
 jenkins_java_options_env_var: JAVA_ARGS


### PR DESCRIPTION
Default __jenkins_pkg_url in vars/Debian.yml contained trailing slash which resulted in URLS like `https://pkg.jenkins.io/debian-stable//jenkins_X.X_all.deb`. vars/RedHat.yml is OK though. Also removed the slash in the examples.