### PR TITLE
Add Check Mode support.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,7 @@
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false
+  always_run: yes
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
   get_url:
@@ -48,6 +49,7 @@
   until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"
   retries: 5
   delay: 10
+  always_run: yes
 
 - name: Remove Jenkins security init scripts after first startup.
   file:


### PR DESCRIPTION
Two tasks failed when the role was run in Check Mode (with --check). The needed opt-out parameter `check_mode` is only available in Ansible 2.2, thus the min version bump.

This is an alternative for #102 and fixes #96.

Would be great if merged and released - what's your opinion?