### PR TITLE
Fix day 2 Jenkins upgrades

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -20,17 +20,17 @@
 - name: Download specific Jenkins version.
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
-    dest: "/tmp/jenkins.deb"
+    dest: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
   when: jenkins_version is defined
 
 - name: Check if we downloaded a specific version of Jenkins.
   stat:
-    path: "/tmp/jenkins.deb"
+    path: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
   register: specific_version
 
 - name: Install our specific version of Jenkins.
   apt:
-    deb: "/tmp/jenkins.deb"
+    deb: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
     state: installed
   when: specific_version.stat.exists
   notify: configure default users

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -27,12 +27,13 @@
   stat:
     path: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
   register: specific_version
+  when: jenkins_version is defined
 
 - name: Install our specific version of Jenkins.
   apt:
     deb: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
     state: installed
-  when: specific_version.stat.exists
+  when: jenkins_version is defined and specific_version.stat.exists
   notify: configure default users
 
 - name: Validate Jenkins is installed and register package name.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -27,12 +27,13 @@
   stat:
     path: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
   register: specific_version
+  when: jenkins_version is defined
 
 - name: Install our specific version of Jenkins.
   package:
     name: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     state: installed
-  when: specific_version.stat.exists
+  when: jenkins_version is defined and specific_version.stat.exists
   notify: configure default users
 
 - name: Validate Jenkins is installed and register package name.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -36,11 +36,11 @@
   when: jenkins_version is defined and specific_version.stat.exists
   notify: configure default users
 
-- name: Validate Jenkins is installed and register package name.
+- name: Validate Jenkins is installed.
   package:
     name: jenkins
     state: present
-  when: not specific_version.stat.exists
+  when: jenkins_version is defined and not specific_version.stat.exists
   notify: configure default users
 
 - name: Install Jenkins from repository.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -20,17 +20,17 @@
 - name: Download specific Jenkins version.
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
-    dest: "/tmp/jenkins.rpm"
+    dest: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
   when: jenkins_version is defined
 
 - name: Check if we downloaded a specific version of Jenkins.
   stat:
-    path: "/tmp/jenkins.rpm"
+    path: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
   register: specific_version
 
 - name: Install our specific version of Jenkins.
   package:
-    name: "/tmp/jenkins.rpm"
+    name: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     state: installed
   when: specific_version.stat.exists
   notify: configure default users


### PR DESCRIPTION
Fix for day 2 upgrades on Jenkins.

The get_url module by default does not download the file from the source URL if it already exists on the system. This does not mean it does'nt download the file from the URL if it's the "same" as the one system, but rather it will not download the file if a file with the same name already exists - I detect no consideration for the contents or hash of the source and dest files. This causes an issue when you already have Jenkins installed using the module and decide to bump up the version. In my case this was from 2.32.2 to 2.46.1. But the role executed without any changes. The cause was the get_url module and how it works: http://docs.ansible.com/ansible/get_url_module.html

My updates provide a way to resolve this situation while maintaining idempotency (not using get_url's force: true). By adding the specified jenkins version to the name of the downloaded rpm (or deb) this issue is resolved, and will not trigger changes on subsequent runs with the same Jenkins version.

Current version of the role with issue (jenkins-2.46.1-1.1.noarch.rpm downloaded, but /tmp/jenkins.rpm is not updated and is really jenkins-2.32.2-1.1.noarch.rpm):
````bash
TASK [geerlingguy.jenkins : Add Jenkins repo GPG key.] *************************
ok: [testhost] => {"changed": false}

TASK [geerlingguy.jenkins : Download specific Jenkins version.] ****************
ok: [testhost] => {"changed": false, "dest": "/tmp/jenkins.rpm", "gid": 0, "group": "root", "mode": "0644", "msg": "file already exists", "owner": "root", "secontext": "unconfined_u:object_r:user_tmp_t:s0", "size": 69675473, "state": "file", "uid": 0, "url": "https://pkg.jenkins.io/redhat-stable/jenkins-2.46.1-1.1.noarch.rpm"}

TASK [geerlingguy.jenkins : Check if we downloaded a specific version of Jenkins.] ***
ok: [testhost] => {"changed": false, "stat": {"atime": 1492206024.3180711, "checksum": "31eb8d8354f9758856810d27cda15a25649e7562", "ctime": 1489203934.193202, "dev": 64768, "executable": false, "exists": true, "gid": 0, "gr_name": "root", "inode": 101723202, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "md5": "aa745820c0e2447ea3deffb1aa04a1ed", "mode": "0644", "mtime": 1489203934.193202, "nlink": 1, "path": "/tmp/jenkins.rpm", "pw_name": "root", "readable": true, "rgrp": true, "roth": true, "rusr": true, "size": 69675473, "uid": 0, "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}}

TASK [geerlingguy.jenkins : Install our specific version of Jenkins.] **********
changed: [testhost] => {"changed": true, "msg": "", "rc": 0, "results": ["Loaded plugins: fastestmirror\nExamining /tmp/jenkins.rpm: jenkins-2.32.2-1.1.noarch\nMarking /tmp/jenkins.rpm to be installed\nResolving Dependencies\n--> Running transaction check\n---> Package jenkins.noarch 0:2.32.2-1.1 will be installed\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package          Arch            Version               Repository         Size\n================================================================================\nInstalling:\n jenkins          noarch          2.32.2-1.1            /jenkins           67 M\n\nTransaction Summary\n================================================================================\nInstall  1 Package\n\nTotal size: 67 M\nInstalled size: 67 M\nDownloading packages:\nRunning transaction check\nRunning transaction test\nTransaction test succeeded\nRunning transaction\n  Installing : jenkins-2.32.2-1.1.noarch                                    1/1 \n  Verifying  : jenkins-2.32.2-1.1.noarch                                    1/1 \n\nInstalled:\n  jenkins.noarch 0:2.32.2-1.1                                                   \n\nComplete!\n"]}

TASK [geerlingguy.jenkins : Validate Jenkins is installed and register package name.] ***
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}
````

Updated version with correct/expected results:
````bash
TASK [geerlingguy.jenkins : Add Jenkins repo GPG key.] *************************
ok: [testhost] => {"changed": false}

TASK [geerlingguy.jenkins : Download specific Jenkins version.] ****************
ok: [testhost] => {"changed": false, "dest": "/tmp/jenkins-2.46.1-1.1.noarch.rpm", "gid": 0, "group": "root", "mode": "0644", "msg": "file already exists", "owner": "root", "secontext": "unconfined_u:object_r:user_tmp_t:s0", "size": 68470530, "state": "file", "uid": 0, "url": "https://pkg.jenkins.io/redhat-stable/jenkins-2.46.1-1.1.noarch.rpm"}

TASK [geerlingguy.jenkins : Check if we downloaded a specific version of Jenkins.] ***
ok: [testhost] => {"changed": false, "stat": {"atime": 1492210688.0, "checksum": "7625509d7468ac4bc992a4435181f2a05277d366", "ctime": 1492210688.7262251, "dev": 64768, "executable": false, "exists": true, "gid": 0, "gr_name": "root", "inode": 101702937, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "md5": "ae0ed087c4e6534f9580d4c2f99726df", "mode": "0644", "mtime": 1490822137.0, "nlink": 1, "path": "/tmp/jenkins-2.46.1-1.1.noarch.rpm", "pw_name": "root", "readable": true, "rgrp": true, "roth": true, "rusr": true, "size": 68470530, "uid": 0, "wgrp": false, "woth": false, "writeable": true, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}}

TASK [geerlingguy.jenkins : Install our specific version of Jenkins.] **********
changed: [testhost] => {"changed": true, "msg": "", "rc": 0, "results": ["Loaded plugins: fastestmirror\nExamining /tmp/jenkins-2.46.1-1.1.noarch.rpm: jenkins-2.46.1-1.1.noarch\nMarking /tmp/jenkins-2.46.1-1.1.noarch.rpm as an update to jenkins-2.32.2-1.1.noarch\nResolving Dependencies\n--> Running transaction check\n---> Package jenkins.noarch 0:2.32.2-1.1 will be updated\n---> Package jenkins.noarch 0:2.46.1-1.1 will be an update\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package      Arch        Version         Repository                       Size\n================================================================================\nUpdating:\n jenkins      noarch      2.46.1-1.1      /jenkins-2.46.1-1.1.noarch       65 M\n\nTransaction Summary\n================================================================================\nUpgrade  1 Package\n\nTotal size: 65 M\nDownloading packages:\nRunning transaction check\nRunning transaction test\nTransaction test succeeded\nRunning transaction\n  Updating   : jenkins-2.46.1-1.1.noarch                                    1/2 \n  Cleanup    : jenkins-2.32.2-1.1.noarch                                    2/2 \n  Verifying  : jenkins-2.46.1-1.1.noarch                                    1/2 \n  Verifying  : jenkins-2.32.2-1.1.noarch                                    2/2 \n\nUpdated:\n  jenkins.noarch 0:2.46.1-1.1                                                   \n\nComplete!\n"]}

TASK [geerlingguy.jenkins : Validate Jenkins is installed and register package name.] ***
skipping: [testhost] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}
````
