### PR TITLE
Plugins token

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Default admin account credentials which will be created the first time Jenkins i
 
 Default admin password file which will be created the first time Jenkins is installed as /var/lib/jenkins/secrets/initialAdminPassword
 
+    jenkins_admin_token: ""
+
+Default admin token which will be generated after installation. It's helpfull to update plugins using an admin account absent of the LDAP.
+
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Default admin password file which will be created the first time Jenkins is inst
 
 Default admin token which will be generated after installation. It's helpfull to update plugins using an admin account absent of the LDAP.
 
+    jenkins_admin_token_file: ""
+
+Default admin token file which you have to creates after the installation with the generated token. It's helpfull to update plugins using an admin account absent of the LDAP.
+
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,7 @@ jenkins_admin_username: admin
 jenkins_admin_password: admin
 jenkins_admin_password_file: ""
 jenkins_admin_token: ""
+jenkins_admin_token_file: ""
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ jenkins_plugin_updates_expiration: 86400
 jenkins_admin_username: admin
 jenkins_admin_password: admin
 jenkins_admin_password_file: ""
+jenkins_admin_token: ""
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -12,6 +12,18 @@
     jenkins_admin_password: "{{ adminpasswordfile['stdout'] | default(jenkins_admin_password) }}"
   no_log: True
 
+- name: Get Jenkins admin token from file.
+  slurp:
+    src: "{{ jenkins_admin_token_file }}"
+  register: admintokenfile
+  no_log: True
+  when: jenkins_admin_token_file != ""
+
+- name: Set Jenkins admin token fact.
+  set_fact:
+    jenkins_admin_token: "{{ admintokenfile['stdout'] | default(jenkins_admin_token) }}"
+  no_log: True
+
 - name: Install Jenkins plugins using password.
   jenkins_plugin:
     name: "{{ item }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,7 +1,8 @@
 ---
 # jenkins_plugin module doesn't support password files.
 - name: Get Jenkins admin password from file.
-  command: "cat {{ jenkins_admin_password_file }}"
+  slurp:
+    src: "{{ jenkins_admin_password_file }}"
   register: adminpasswordfile
   no_log: True
   when: jenkins_admin_password_file != ""

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -12,7 +12,7 @@
     jenkins_admin_password: "{{ adminpasswordfile['stdout'] | default(jenkins_admin_password) }}"
   no_log: True
 
-- name: Install Jenkins plugins.
+- name: Install Jenkins plugins using password.
   jenkins_plugin:
     name: "{{ item }}"
     params:
@@ -21,4 +21,16 @@
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
   with_items: "{{ jenkins_plugins }}"
+  when: jenkins_admin_password != ""
+  notify: restart jenkins
+
+- name: Install Jenkins plugins using token.
+  jenkins_plugin:
+    name: "{{ item }}"
+    params:
+      url_token: "{{ jenkins_admin_token }}"
+    updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
+    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
+  with_items: "{{ jenkins_plugins }}"
+  when: jenkins_admin_token != ""
   notify: restart jenkins


### PR DESCRIPTION
Once the jenkins master is installed, we often connect it to an LDAP server.
In my case the admin account is not defined in the LDAP for some security reasons.

Before connect the Jenkins master to the LDAP, I can retrieve the admin token, connect Jenkins to the LDAP and use the token to update the plugins.
And so, if I want to continue to manage my plugins updates with this role, I need a such enhancement.

So I suggest to create jenkins_admin_token and jenkins_admin_token_file to use the `url_token` params of `jenkins_plugins`.

By the way, commit https://github.com/olo-dw/ansible-role-jenkins/commit/2bc26e0d2ffdf7a357b0c09ab7001efe07dc6b13 improves the idempotence using the slurp module instead of command
