### PR TITLE
Support overriding timeout when installing plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Jenkins plugins to be installed automatically during provisioning.
     
 Number of seconds after which a new copy of the update-center.json file is downloaded. Set it to 0 if no cache file should be used.
 
+    jenkins_plugin_timeout: 30
+
+The server connection timeout, in seconds, when installing Jenkins plugins.
+
     jenkins_version: "1.644"
     jenkins_pkg_url: "http://www.example.com"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,7 @@ jenkins_plugins: []
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 jenkins_plugin_updates_expiration: 86400
-jenkins_plugins_timeout: 30
+jenkins_plugin_timeout: 30
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ jenkins_plugins: []
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 jenkins_plugin_updates_expiration: 86400
+jenkins_plugins_timeout: 30
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -17,7 +17,7 @@
     params:
       url_username: "{{ jenkins_admin_username }}"
       url_password: "{{ jenkins_admin_password }}"
-    timeout: "{{ jenkins_plugins_timeout }}"
+    timeout: "{{ jenkins_plugin_timeout }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
   with_items: "{{ jenkins_plugins }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -17,6 +17,7 @@
     params:
       url_username: "{{ jenkins_admin_username }}"
       url_password: "{{ jenkins_admin_password }}"
+    timeout: "{{ jenkins_plugins_timeout }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
   with_items: "{{ jenkins_plugins }}"

--- a/tests/test-plugins.yml
+++ b/tests/test-plugins.yml
@@ -3,7 +3,11 @@
 
   vars:
     jenkins_plugins:
-      - ant
+      - blueocean
+      - ghprb
+      - greenballs
+      - workflow-aggregator
+    jenkins_plugins_timeout: 120
 
   pre_tasks:
     - include: java-8.yml

--- a/tests/test-plugins.yml
+++ b/tests/test-plugins.yml
@@ -7,7 +7,7 @@
       - ghprb
       - greenballs
       - workflow-aggregator
-    jenkins_plugins_timeout: 120
+    jenkins_plugin_timeout: 120
 
   pre_tasks:
     - include: java-8.yml


### PR DESCRIPTION
I found that it takes more than 30 secs for some plugins to be installed, so that's the purpose of this pull: allow configuring the timeout using a predefined variable