### PR TITLE
set the owner of the basic-security script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,6 +19,9 @@ jenkins_admin_username: admin
 jenkins_admin_password: admin
 jenkins_admin_password_file: ""
 
+jenkins_process_user: jenkins
+jenkins_process_group: "{{ jenkins_process_user }}"
+
 jenkins_init_changes:
   - option: "JENKINS_ARGS"
     value: "--prefix={{ jenkins_url_prefix }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,4 +6,7 @@
   template:
     src: basic-security.groovy
     dest: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0775
   register: jenkins_users_config

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -33,8 +33,8 @@
   file:
     path: "{{ jenkins_home }}/init.groovy.d"
     state: directory
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0775
 
 - name: Trigger handlers immediately in case Jenkins was installed


### PR DESCRIPTION
I was getting a permission denied error when Jenkins was trying to start and read `basic-security.groovy`, because the file was owned by `root`. This change makes the file ownership explicit.