### PR TITLE
restart jenkins to ensure service is running

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,11 @@
 - name: Ensure Jenkins is started and runs on startup.
   service: name=jenkins state=started enabled=yes
 
+# The above step fails sometimes (noticed in RHEL 7.2 and 7.3).
+# This restart tries to mitigate that.
+- name: Restart Jenkins once to mitigate service startup failures.
+  service: name=jenkins state=restarted
+
 - name: Wait for Jenkins to start up before proceeding.
   shell: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
   register: result


### PR DESCRIPTION
I have noticed on RHEL 7.2 and 7.3 that without a restart, the ensuing curl command times out after 60 retries, and the role fails.

This commit fixes the issue.


```
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (9 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (8 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (7 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (6 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (5 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (4 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (3 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (2 retries left).
FAILED - RETRYING: Wait for Jenkins to start up before proceeding. (1 retries left).
 [WARNING]: Consider using get_url or uri module rather than running curl

fatal: [XX.XX.XX.XX]: FAILED! => {"attempts": 60, "changed": false, "cmd": "curl -D - --silent --max-time 5 http://localhost:8080/cli/", "delta": "0:00:00.009602", "end": "2017-06-12 16:31:34.820858", "failed": true, "rc": 7, "start": "2017-06-12 16:31:34.811256", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
	to retry, use: --lim######
```