### PR TITLE
Honor jenkins_home variable from jenkins_plugin module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,12 @@ env:
     prefix: ''
     http_port: 8080
 
+ # tests/test-plugins-with-home.yml
+  - distro: ubuntu1604
+    playbook: test-plugins-with-home.yml
+    prefix: ''
+    http_port: 8080
+
   # tests/test-plugins-with-pinning.yml
   - distro: ubuntu1604
     playbook: test-plugins-with-pinning.yml

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -27,6 +27,7 @@
 - name: Install Jenkins plugins using password.
   jenkins_plugin:
     name: "{{ item }}"
+    jenkins_home: "{{ jenkins_home }}"
     params:
       url_username: "{{ jenkins_admin_username }}"
       url_password: "{{ jenkins_admin_password }}"

--- a/tests/test-plugins-with-home.yml
+++ b/tests/test-plugins-with-home.yml
@@ -1,0 +1,15 @@
+---
+- hosts: all
+
+  vars:
+    jenkins_plugins:
+      - greenballs
+    jenkins_home: /tmp/jenkins
+    jenkins_plugin_timeout: 120
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - role_under_test


### PR DESCRIPTION
If you set jenkins_home and install any plugin, then the overridden variable is not applied to the jenkins_plugin Ansible module, so the plugin tries to be installed in `/var/lib/jenkins` instead of the new path