### PR TITLE
option to disable repo download

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This role will install the latest version of Jenkins by default (using the offic
 
     jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
-It is also possible stop the repo file being added by setting jenkins_repo_url = 'disabled'.  This is useful if you signing your own packages or running internal package management - such as Spacewalk.
+It is also possible stop the repo file being added by setting jenkins_repo_url = ''.  This is useful if you signing your own packages or running internal package management - such as Spacewalk.
 
 Extra Java options for the Jenkins launch command configured in the init file can be set with the var `jenkins_java_options`. By default the option to disable the Jenkins 2.0 setup wizard is added.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ This role will install the latest version of Jenkins by default (using the offic
 
     jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
+It is also possible stop the repo file being added by setting jenkins_repo_url = 'disabled'.  This is useful if you signing your own packages or running internal package management - such as Spacewalk.
+
 Extra Java options for the Jenkins launch command configured in the init file can be set with the var `jenkins_java_options`. By default the option to disable the Jenkins 2.0 setup wizard is added.
 
     jenkins_init_changes:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,6 +16,8 @@
     repo: "{{ jenkins_repo_url }}"
     state: present
     update_cache: yes
+  when: jenkins_repo_url != 'disabled'
+
 
 - name: Download specific Jenkins version.
   get_url:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -16,7 +16,7 @@
     repo: "{{ jenkins_repo_url }}"
     state: present
     update_cache: yes
-  when: jenkins_repo_url != 'disabled'
+  when: jenkins_repo_url != ''
 
 
 - name: Download specific Jenkins version.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -11,7 +11,7 @@
   get_url:
     url: "{{ jenkins_repo_url }}"
     dest: /etc/yum.repos.d/jenkins.repo
-  when: jenkins_repo_url != 'disabled'
+  when: jenkins_repo_url != ''
 
 - name: Add Jenkins repo GPG key.
   rpm_key:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -11,6 +11,7 @@
   get_url:
     url: "{{ jenkins_repo_url }}"
     dest: /etc/yum.repos.d/jenkins.repo
+  when: jenkins_repo_url != 'disabled'
 
 - name: Add Jenkins repo GPG key.
   rpm_key:


### PR DESCRIPTION
A small change to allow a user to disable the repo fetching task in the setup playbooks. 
For systems that sign their own RPMs / DEBs - this stops the role from running.   