### PR TITLE
use apt to install specific versions from repo

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -17,23 +17,11 @@
     state: present
     update_cache: yes
 
-- name: Download specific Jenkins version.
-  get_url:
-    url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
-    dest: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
-  when: jenkins_version is defined
-
-- name: Check if we downloaded a specific version of Jenkins.
-  stat:
-    path: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
-  register: specific_version
-  when: jenkins_version is defined
-
-- name: Install our specific version of Jenkins.
+- name: Ensure specific Jenkins version is installed.
   apt:
-    deb: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
-    state: installed
-  when: jenkins_version is defined and specific_version.stat.exists
+    name: "jenkins={{ jenkins_version }}"
+    state: "{{ jenkins_package_state }}"
+  when: jenkins_version is defined
   notify: configure default users
 
 - name: Ensure Jenkins is installed.


### PR DESCRIPTION
I think when a package repo is available, packages should be installed with the system package manager, not downloaded with curl  or get_url.
apt can install a specific package version with "apt-get install package_name=package_version", so I replaced the get_url and install local deb part with an apt call.
When setting "jenkins_version" to "2.60.1-1", for example, this results in
"apt-get install jenkins=2.60.1-1"

Same should be possible for dnf / yum, but I can't check this out right now.