### PR TITLE
Write admin token to file during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A Jenkins API token (generated after installation) for [authenticated scripted c
 
     jenkins_admin_token_file: ""
 
-A file (with full path) on the Jenkins server containing the admin token. If this variable is set in addition to the `jenkins_admin_token`, the contents of this file will overwrite the value of `jenkins_admin_token`.
+A file (with full path) on the Jenkins server containing the admin token. If this variable is set in addition to the `jenkins_admin_token`, the contents of this file will overwrite the value of `jenkins_admin_token`. If you specify a non-existing filepath the token generated during the installation will be written into that file.
 
     jenkins_jar_location: /opt/jenkins-cli.jar
 

--- a/templates/basic-security.groovy
+++ b/templates/basic-security.groovy
@@ -1,6 +1,7 @@
 #!groovy
 import hudson.security.*
 import jenkins.model.*
+import jenkins.security.*
 
 def instance = Jenkins.getInstance()
 def hudsonRealm = new HudsonPrivateSecurityRealm(false)
@@ -25,4 +26,15 @@ else {
     def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
     instance.setAuthorizationStrategy(strategy)
     instance.save()
+}
+
+def tokenFilePath = '{{ jenkins_admin_token_file }}'
+def tokenFile = new File(tokenFilePath)
+
+if (tokenFilePath && !tokenFile.exists()) {
+    def user = hudson.model.User.get('admin')
+    ApiTokenProperty t = user.getProperty(ApiTokenProperty.class)
+    def token = t.getApiToken()
+    tokenFile.write(token)
+    println "--> wrote admin api token to ${tokenFilePath}"
 }


### PR DESCRIPTION
During the basic security setup write admin user api token into the user
specified filepath. This allow bootstrapping the installation with a
known secret (admin password) but continue by using the token once it
has been generated. This is especially helpful if user configures such
a security realm that effectively disables the password login of the
original admin user.