### PR TITLE
fix for password from file

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -6,10 +6,16 @@
   register: adminpasswordfile
   no_log: True
   when: jenkins_admin_password_file != ""
+  
+- name: Get decrypted Jenkins password from passwordfile
+  shell: echo {{ adminpasswordfile.content | b64decode }}
+  register: passwordfromfile
+  always_run: yes
+  when:  jenkins_admin_password_file != ""
 
 - name: Set Jenkins admin password fact.
   set_fact:
-    jenkins_admin_password: "{{ adminpasswordfile['stdout'] | default(jenkins_admin_password) }}"
+    jenkins_admin_password: "{{ passwordfromfile['stdout'] | default(jenkins_admin_password) }}"
   no_log: True
 
 - name: Get Jenkins admin token from file.


### PR DESCRIPTION
hi,

here I have added a fix for taking Jenkins password from initial password file. previously the content of the file was encrypted using slurp but then without decoding was used in next subtask so the actual password was not reflecting.

added a subtask to decode the password before using the same. only relevant when user is trying to read password from a file