### PR TITLE
wait for jenkins to be ready with restart handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,13 @@ env:
     prefix: ''
     http_port: 8080
 
+  # tests/test-handler.yml
+  - distro: ubuntu1604
+    playbook: test-handler.yml
+    test_idempotence: false
+    prefix: ''
+    http_port: 8080
+
 script:
   # Configure test script so we can run extra tests after playbook is run.
   - export container_id=$(date +%s)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart jenkins
-  service: name=jenkins state=restarted
+  include: restart_jenkins.yml
 
 - name: configure default users
   template:

--- a/handlers/restart_jenkins.yml
+++ b/handlers/restart_jenkins.yml
@@ -1,0 +1,5 @@
+---
+- name: ensure jenkins is restarted
+  service: name=jenkins state=restarted
+
+- include: ../tasks/wait_for_jenkins.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,14 +32,7 @@
 - name: Ensure Jenkins is started and runs on startup.
   service: name=jenkins state=started enabled=yes
 
-- name: Wait for Jenkins to start up before proceeding.
-  shell: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
-  register: result
-  until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
-  retries: "{{ jenkins_connection_retries }}"
-  delay: "{{ jenkins_connection_delay }}"
-  changed_when: false
-  check_mode: no
+- include: wait_for_jenkins.yml
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
   get_url:

--- a/tasks/wait_for_jenkins.yml
+++ b/tasks/wait_for_jenkins.yml
@@ -1,0 +1,9 @@
+---
+- name: Wait for Jenkins to start up before proceeding.
+  shell: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
+  register: result
+  until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
+  retries: "{{ jenkins_connection_retries }}"
+  delay: "{{ jenkins_connection_delay }}"
+  changed_when: false
+  check_mode: no

--- a/tests/test-handler.yml
+++ b/tests/test-handler.yml
@@ -1,0 +1,24 @@
+---
+- hosts: all
+
+  pre_tasks:
+    - include: java-8.yml
+
+  roles:
+    - geerlingguy.java
+    - role_under_test
+
+  tasks:
+    - name: this task notifies handler to restart jenkins
+      debug:
+          msg: 'trigger jenkins restart'
+      notify: restart jenkins
+      changed_when: true
+
+    - name: force all notified handlers to run at this point, not waiting for normal sync points
+      meta: flush_handlers
+
+    - name: ensure jenkins is ready
+      uri:
+          url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}"
+          status_code: 200


### PR DESCRIPTION
Currently the "restart jenkins" handler does not wait for Jenkins to be ready.
Therefore some commands sent to Jenkins are likely to fail when executed right after Jenkins gets restarted.
This small fix is about factorising the already existing "Wait for Jenkins" task to be used with the "restart jenkins" handler.

BTW thanks for the great roles you share - definitely a great value! \o/