### PR TITLE
Demonstrate that America/Los_Angeles is not a valid timezone in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,12 @@ env:
     prefix: ''
     http_port: 8080
 
+ # tests/test-timezone.yml
+  - distro: ubuntu1604
+    playbook: test-timezone.yml
+    prefix: ''
+    http_port: 8080
+
 script:
   # Configure test script so we can run extra tests after playbook is run.
   - export container_id=$(date +%s)

--- a/tests/test-timezone.yml
+++ b/tests/test-timezone.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+
+  vars:
+    jenkins_version: 1.644
+
+  pre_tasks:
+    - name: Update timezone.
+      become: yes
+      timezone:
+        name: "America/Los_Angeles"
+
+  roles:
+    - geerlingguy.java
+    - role_under_test

--- a/tests/test-timezone.yml
+++ b/tests/test-timezone.yml
@@ -5,6 +5,9 @@
     jenkins_version: 1.644
 
   pre_tasks:
+    - name: "Install dbus"
+      become: yes
+      apt: "name=dbus state=latest update_cache=true"
     - name: "List timezones"
       become: yes
       command: "timedatectl list-timezones"

--- a/tests/test-timezone.yml
+++ b/tests/test-timezone.yml
@@ -5,6 +5,12 @@
     jenkins_version: 1.644
 
   pre_tasks:
+    - name: "List timezones"
+      become: yes
+      command: "timedatectl list-timezones"
+      register: timezones
+    - name: "Debug"
+      debug: msg="{{ timezones.stdout }}"
     - name: Update timezone.
       become: yes
       timezone:


### PR DESCRIPTION
Hey @geerlingguy, this PR just adds a test to demonstrate that the timezone is not properly set on tests. Not sure if the error comes from the docker container we use to setup the test environment, as I consider this `America/Los_Angeles` timezone as a valid timezone value.

Thanks!