### PR TITLE
Jenkins needs to be restarted after installation of plugins

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -49,3 +49,6 @@
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_token != ""
   notify: restart jenkins
+
+- name: Restart jenkins to be able to use jenkins-cli
+  meta: flush_handlers


### PR DESCRIPTION
As you might now, handlers runs at the very end of the playbook.
That causes issues while you are using this role and trying to configure
Jenkins with the next role/tasks.

Jenkins restart might happen just after the installation of the plugins.
So that, I can configure some of the plugins by jenkins-cli