### PR TITLE
Plugin Database Update

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -35,14 +35,14 @@
 - name: Download current plugin updates from Jenkins update site
   get_url:
     url: http://updates.jenkins-ci.org/update-center.json
-    dest: /var/lib/jenkins/updates/default.json
+    dest: "{{ jenkins_home}}/updates/default.json"
     owner: jenkins
     group: jenkins
     mode: 0440
 
 - name: Remove first and last line from json file
   replace: 
-    path: /var/lib/jenkins/updates/default.json
+    path: "{{ jenkins_home }}/updates/default.json"
     regexp: "1d;$d"
 
 - name: Install Jenkins plugins using password.

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -24,6 +24,27 @@
     jenkins_admin_token: "{{ admintokenfile['stdout'] | default(jenkins_admin_token) }}"
   no_log: True
 
+# Update Jenkins so that plugin updates don't fail
+- name: Create update directory
+  file: 
+    path: "{{ jenkins_home }}/updates"
+    state: directory
+    owner: jenkins
+    group: jenkins
+
+- name: Download current plugin updates from Jenkins update site
+  get_url:
+    url: http://updates.jenkins-ci.org/update-center.json
+    dest: /var/lib/jenkins/updates/default.json
+    owner: jenkins
+    group: jenkins
+    mode: 0440
+
+- name: Remove first and last line from json file
+  replace: 
+    path: /var/lib/jenkins/updates/default.json
+    regexp: "1d;$d"
+
 - name: Install Jenkins plugins using password.
   jenkins_plugin:
     name: "{{ item }}"


### PR DESCRIPTION
* Update plugin database before installing Jenkins plugins (eliminates build failures).  See the following for additional information - 
- http://www.mymiller.name/wordpress/app/1515/
- https://www.jeffgeerling.com/blog/2017/ansible-jenkinsplugin-module-and-404-plugin-not-found