### PR TITLE
Option to disable downloading repo_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This role will install the latest version of Jenkins by default (using the offic
     jenkins_repo_url: deb http://pkg.jenkins-ci.org/debian-stable binary/
     jenkins_repo_key_url: http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key
 
-It is also possible stop the repo file being added by setting  `jenkins_repo_url = ''`. This is useful if, for example, you sign your own packages or run internal package management (e.g. Spacewalk).
+It is also possible to stop the repo-file and repo-key being added by setting `jenkins_repo_url = ''` and `jenkins_repo_key_url = ''`. This is useful if, for example, you sign your own packages or run internal package management (e.g. Spacewalk).
 
     jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,6 +10,7 @@
   apt_key:
     url: "{{ jenkins_repo_key_url }}"
     state: present
+  when: jenkins_repo_key_url != ''
 
 - name: Add Jenkins apt repository.
   apt_repository:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -17,6 +17,7 @@
   rpm_key:
     state: present
     key: "{{ jenkins_repo_key_url }}"
+  when: jenkins_repo_key_url != ''
 
 - name: Download specific Jenkins version.
   get_url:


### PR DESCRIPTION
Analogous to https://github.com/geerlingguy/ansible-role-jenkins/pull/148, this disables downloading the repo key if it is empty.