### PR TITLE
settings: Allow recursive chown on jenkins_home

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ jenkins_package_state: present
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
+jenkins_home_recurse_chown: "no"
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -36,6 +36,7 @@
     owner: jenkins
     group: jenkins
     mode: u+rwx
+    recurse: "{{ jenkins_home_recurse_chown }}"
 
 - name: Create custom init scripts directory.
   file:


### PR DESCRIPTION
When mounting/using an existing `jenkins_home` on a fresh install of
jenkins, the UID of the jenkins user may change causing jenkins to
silently fail to start. This option allows running the chown as part of
the ansible task if desired (defaults to no to preserve existing
behavior).