### PR TITLE
Install plugins with dependencies by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ The location at which the `jenkins-cli.jar` jarfile will be kept. This is used f
 
 Jenkins plugins to be installed automatically during provisioning.
 
+    jenkins_plugin_with_dependencies: yes
+
+Jenkins plugins to be installed with their dependencies.
+
     jenkins_plugins_state: present
 
 Use `latest` to ensure all plugins are running the most up-to-date version.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,7 @@ jenkins_plugins: []
 jenkins_plugins_state: present
 jenkins_plugin_updates_expiration: 86400
 jenkins_plugin_timeout: 30
+jenkins_plugin_with_dependencies: yes
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -56,6 +56,7 @@
     timeout: "{{ jenkins_plugin_timeout }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
+    with_dependencies: yes
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_password != ""
   notify: restart jenkins

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -56,7 +56,7 @@
     timeout: "{{ jenkins_plugin_timeout }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
-    with_dependencies: yes
+    with_dependencies: "{{ jenkins_plugin_with_dependencies }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_password != ""
   notify: restart jenkins
@@ -68,6 +68,7 @@
       url_token: "{{ jenkins_admin_token }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
+    with_dependencies: "{{ jenkins_plugin_with_dependencies }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_token != ""
   notify: restart jenkins


### PR DESCRIPTION
I wanted to install the pipeline plugin and needed all it's dependencies installed too. I thought that it made sense to install plugins and their dependencies in general.