### PR TITLE
Allow jenkins_home to be a symlink

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -36,6 +36,7 @@
     owner: jenkins
     group: jenkins
     mode: u+rwx
+    follow: true
 
 - name: Create custom init scripts directory.
   file:


### PR DESCRIPTION
On constrained space one might move /var/lib/jenkins elsewhere and keep
the old location as a symlink. So follow that instead of failing.