### PR TITLE
Add switch for disabling proxy get_url fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Extra Java options for the Jenkins launch command configured in the init file ca
 
 Changes made to the Jenkins init script; the default set of changes set the configured URL prefix and add in configured Java options for Jenkins' startup. You can add other option/value pairs if you need to set other options for the Jenkins init file.
 
+    jenkins_use_proxy: yes
+
+Whether or not to use the system supplied proxy when fetching information via `get_url`.
+
 ## Dependencies
 
   - geerlingguy.java

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,4 +36,4 @@ jenkins_init_changes:
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
 
-jenkins_use_proxy: yes
+jenkins_use_proxy: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ jenkins_init_changes:
     value: "--prefix={{ jenkins_url_prefix }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
+
+jenkins_use_proxy: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,4 +36,4 @@ jenkins_init_changes:
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
 
-jenkins_use_proxy: no
+jenkins_use_proxy: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
   get_url:
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/jnlpJars/jenkins-cli.jar"
     dest: "{{ jenkins_jar_location }}"
+    use_proxy: "{{ jenkins_use_proxy }}"
   register: jarfile_get
   until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"
   retries: 5

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -39,6 +39,7 @@
     owner: jenkins
     group: jenkins
     mode: 0440
+    use_proxy: "{{ jenkins_use_proxy }}"
 
 - name: Remove first and last line from json file
   replace:

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -22,6 +22,7 @@
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
     dest: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
+    use_proxy: "{{ jenkins_use_proxy }}"
   when: jenkins_version is defined
 
 - name: Check if we downloaded a specific version of Jenkins.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -11,6 +11,7 @@
   get_url:
     url: "{{ jenkins_repo_url }}"
     dest: /etc/yum.repos.d/jenkins.repo
+    use_proxy: "{{ jenkins_use_proxy }}"
   when: jenkins_repo_url != ''
 
 - name: Add Jenkins repo GPG key.
@@ -22,6 +23,7 @@
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     dest: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
+    use_proxy: "{{ jenkins_use_proxy }}"
   when: jenkins_version is defined
 
 - name: Check if we downloaded a specific version of Jenkins.


### PR DESCRIPTION
Working from https://github.com/geerlingguy/ansible-role-jenkins/pull/120 this change aims to modify the behavior of all `get_url` fetches so that the proxy behavior can optionally be enabled or disabled.