### PR TITLE
Stop using the params argument to jenkins_plugin

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -49,8 +49,7 @@
   jenkins_plugin:
     name: "{{ item }}"
     jenkins_home: "{{ jenkins_home }}"
-    params:
-      url_username: "{{ jenkins_admin_username }}"
+    url_username: "{{ jenkins_admin_username }}"
     url_password: "{{ jenkins_admin_password }}"
     state: "{{ jenkins_plugins_state }}"
     timeout: "{{ jenkins_plugin_timeout }}"
@@ -63,8 +62,7 @@
 - name: Install Jenkins plugins using token.
   jenkins_plugin:
     name: "{{ item }}"
-    params:
-      url_token: "{{ jenkins_admin_token }}"
+    url_token: "{{ jenkins_admin_token }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
   with_items: "{{ jenkins_plugins }}"


### PR DESCRIPTION
The params argument has been deprecated. We can pass the params as bare
args to the task instead.

Fixes #199.