### PR TITLE
 Fixed bug for 'unsupported parameter for module: path' error

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -42,7 +42,7 @@
 
 - name: Remove first and last line from json file
   replace:
-    path: "{{ jenkins_home }}/updates/default.json"
+    dest: "{{ jenkins_home }}/updates/default.json"
     regexp: "1d;$d"
 
 - name: Install Jenkins plugins using password.


### PR DESCRIPTION
Re-submitting the PR after pull from upstream and fixing merge conflicts 

This fixes the bug which gives this error: fatal: [10.3.34.26]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: path"}