### PR TITLE
Reduce 'changed' noise for plugin-updates download task

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -39,6 +39,7 @@
     owner: jenkins
     group: jenkins
     mode: 0440
+  changed_when: false
 
 - name: Remove first and last line from json file
   replace:


### PR DESCRIPTION
I have found that the 'changed' noise for this task is not meaningful in practice and becomes an irritant over time (_eg_ when reviewing Ansible playbook run logs that execute this role each day). It seems like an improvement to not report this as ever being 'changed'.
 
I appreciate you considering this change. Thanks for this very useful role.
