### PR TITLE
Allow jenkins to run as a user other than the default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@ jenkins_package_state: present
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
+jenkins_log_dir: /var/log/jenkins
+jenkins_cache_dir: /var/cache/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -29,15 +29,15 @@
   file:
     path: "{{ jenkins_home }}/updates"
     state: directory
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
 
 - name: Download current plugin updates from Jenkins update site
   get_url:
     url: http://updates.jenkins-ci.org/update-center.json
     dest: "{{ jenkins_home}}/updates/default.json"
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0440
 
 - name: Remove first and last line from json file
@@ -49,6 +49,7 @@
   jenkins_plugin:
     name: "{{ item }}"
     jenkins_home: "{{ jenkins_home }}"
+    owner: "{{ jenkins_process_user }}"
     url_username: "{{ jenkins_admin_username }}"
     url_password: "{{ jenkins_admin_password }}"
     state: "{{ jenkins_plugins_state }}"

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -83,4 +83,6 @@
   service: name=jenkins state=restarted
   when: (jenkins_users_config is defined and jenkins_users_config.changed) or
         (jenkins_http_config is defined and jenkins_http_config.changed) or
-        (jenkins_home_config is defined and jenkins_home_config.changed)
+        (jenkins_home_config is defined and jenkins_home_config.changed) or
+        (jenkins_process_user_config is defined and jenkins_process_user_config.changed) or
+        (jenkins_process_group_config is defined and jenkins_process_group_config.changed)

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -17,6 +17,20 @@
     line: 'JENKINS_HOME={{ jenkins_home }}'
   register: jenkins_home_config
 
+- name: Set the user that Jenkins runs as
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_USER=.*'
+    line: 'JENKINS_USER={{ jenkins_process_user }}'
+  register: jenkins_process_user_config
+
+- name: Set the group that Jenkins runs as
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_GROUP=.*'
+    line: 'JENKINS_GROUP={{ jenkins_process_group }}'
+  register: jenkins_process_group_config
+
 - name: Immediately restart Jenkins on init config changes.
   service: name=jenkins state=restarted
   when: jenkins_init_prefix.changed
@@ -33,8 +47,24 @@
   file:
     path: "{{ jenkins_home }}"
     state: directory
-    owner: jenkins
-    group: jenkins
+    owner: '{{ jenkins_process_user }}'
+    group: '{{ jenkins_process_group }}'
+    mode: u+rwx
+
+- name: Ensure jenkins_log_dir {{ jenkins_log_dir }} exists
+  file:
+    path: "{{ jenkins_log_dir }}"
+    state: directory
+    owner: '{{ jenkins_process_user }}'
+    group: '{{ jenkins_process_group }}'
+    mode: u+rwx
+
+- name: Ensure jenkins_cache_dir {{ jenkins_cache_dir }} exists
+  file:
+    path: "{{ jenkins_cache_dir }}"
+    state: directory
+    owner: '{{ jenkins_process_user }}'
+    group: '{{ jenkins_process_group }}'
     mode: u+rwx
     follow: true
 


### PR DESCRIPTION
Nearly the same as https://github.com/nhemingway/ansible-role-jenkins/tree/nhemingway/192-jenkins-process-user but includes JENKINS_GROUP changes and also changes suggested within geerlingguy/ansible-role-jenkins#193.

Tested on Ubuntu 16.04.