### PR TITLE
raise minimum ansible version to 2.4

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: Jenkins CI
   company: "Midwestern Mac, LLC"
   license: "license (BSD, MIT)"
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
   platforms:
   - name: EL
     versions:


### PR DESCRIPTION
The dependency geerlingguy.java version 1.8.0 uplifted minimum ansible
version to 2.4, so this role won't work without it.