### PR TITLE
Fixed the fake response from ansible about the plugin installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,22 @@ A file (with full path) on the Jenkins server containing the admin token. If thi
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.
 
-    jenkins_plugins: []
+```yaml
+    default: my_jenkins_plugins: []
+```
 
-Jenkins plugins to be installed automatically during provisioning.
+    For example:
 
-    jenkins_plugins_install_dependencies: yes
+```yaml
+    my_jenkins_plugins:
+        token-macro:              # name of the plugin (mandatory)
+            dependencies: yes       # install plugin with dependencies (mandatory)
+        build-pipeline-plugin:    # name of the next plugin (mandatory)
+            version: "1.4.9"        # install specific version of the plugin
+            dependencies: yes       # install plugin with dependencies (mandatory)
+```
 
-Whether Jenkins plugins to be installed should also install any plugin dependencies.
-
-    jenkins_plugins_state: present
-
-Use `latest` to ensure all plugins are running the most up-to-date version.
+Jenkins plugins to be installed automatically during provisioning. Mandarory element is "dependencies" for every plugin. Optionally is the "version" element. See example above.
 
     jenkins_plugin_updates_expiration: 86400
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,11 +16,10 @@ jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
-jenkins_plugins: []
-jenkins_plugins_state: present
+my_jenkins_plugins: []
+
 jenkins_plugin_updates_expiration: 86400
 jenkins_plugin_timeout: 30
-jenkins_plugins_install_dependencies: yes
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,11 +33,16 @@
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
-  shell: "curl -D - --silent --max-time 5 http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/"
-  register: result
-  until: (result.stdout.find("403 Forbidden") != -1) or (result.stdout.find("200 OK") != -1) and (result.stdout.find("Please wait while") == -1)
+  uri:
+    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/cli/
+    status_code: 200
+    timeout: 5
+  register: jenkins_service_result
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
+  until: >
+    'status' in jenkins_service_result and
+    jenkins_service_result['status'] == 200    
   changed_when: false
   check_mode: no
 

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -45,28 +45,81 @@
     path: "{{ jenkins_home }}/updates/default.json"
     regexp: "1d;$d"
 
-- name: Install Jenkins plugins using password.
+- name: Install plugins without a specific version
   jenkins_plugin:
-    name: "{{ item }}"
     jenkins_home: "{{ jenkins_home }}"
     url_username: "{{ jenkins_admin_username }}"
     url_password: "{{ jenkins_admin_password }}"
-    state: "{{ jenkins_plugins_state }}"
     timeout: "{{ jenkins_plugin_timeout }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
-    with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
-  with_items: "{{ jenkins_plugins }}"
-  when: jenkins_admin_password != ""
-  notify: restart jenkins
+    name: "{{ item.key }}"
+    state: "{{ item.value.state }}"
+    with_dependencies: "{{ item.value.dependencies }}"
+  register: my_jenkins_plugin_unversioned
+  when: >
+    'version' not in item.value
+  with_dict: "{{ my_jenkins_plugins }}"
+
+- name: Install plugins with a specific version
+  jenkins_plugin:
+    jenkins_home: "{{ jenkins_home }}"
+    url_username: "{{ jenkins_admin_username }}"
+    url_password: "{{ jenkins_admin_password }}"
+    timeout: "{{ jenkins_plugin_timeout }}"
+    updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
+    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
+    name: "{{ item.key }}"
+    version: "{{ item.value.version }}"
+    state: "{{ item.value.state }}"
+    with_dependencies: "{{ item.value.dependencies }}"
+  register: my_jenkins_plugin_versioned
+  when: >
+    'version' in item.value
+  with_dict: "{{ my_jenkins_plugins }}"
+
+- name: Initiate the fact
+  set_fact:
+    jenkins_restart_required: no
+
+- name: Check if restart is required by any of the versioned plugins
+  set_fact:
+    jenkins_restart_required: yes
+  when: item.changed
+  with_items: "{{ my_jenkins_plugin_versioned.results }}"
+
+- name: Check if restart is required by any of the unversioned plugins
+  set_fact:
+    jenkins_restart_required: yes
+  when: item.changed
+  with_items: "{{ my_jenkins_plugin_unversioned.results }}"
+
+- name: Restart Jenkins if required
+  service:
+    name: jenkins
+    state: restarted
+  when: jenkins_restart_required
+
+- name: Wait for Jenkins to start up
+  uri:
+    url: http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}
+    status_code: 200
+    timeout: 5
+  register: jenkins_service_status
+  retries: "{{ jenkins_connection_retries }}"
+  delay: "{{ jenkins_connection_delay }}"
+  until: >
+      'status' in jenkins_service_status and
+      jenkins_service_status['status'] == 200
+  when: jenkins_restart_required
 
 - name: Install Jenkins plugins using token.
   jenkins_plugin:
-    name: "{{ item }}"
+    name: "{{ item.key }}"
     url_token: "{{ jenkins_admin_token }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
-    with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
-  with_items: "{{ jenkins_plugins }}"
+    with_dependencies: "{{ item.value.dependencies }}"
+  with_items: "{{ my_jenkins_plugins }}"
   when: jenkins_admin_token != ""
   notify: restart jenkins


### PR DESCRIPTION
(Resolves #164)

I fixed the issue that show all requested plugins are installed, but really not installed. The solution based on the official Ansible docs about Jenkins plugin.
I added two new option. Install plugins with exact version number (optionally) and you can decide do you want install the plugin with own dependencies or not.
One interesting thing is the timeout. I haven't any chance to test it. I think the timeout is done the jenkins_plugin will show as installed state maybe instead of error.
The Readme.md is updated as well.

I hope will solve the issue.
