### PR TITLE
Register plugin installation result

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -58,6 +58,7 @@
     with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_password != ""
+  register: jenkins_plugins_installation
   notify: restart jenkins
 
 - name: Install Jenkins plugins using token.
@@ -69,4 +70,5 @@
     with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_token != ""
+  register: jenkins_plugins_installation
   notify: restart jenkins


### PR DESCRIPTION
To allow downstream tasks to run conditionally

For example, restarting Jenkins inline during task execution to allow for Groovy scripts to be run against the installed plugins later on in the playbook
```yaml
- name: restart jenkins
  service: name=jenkins state=restarted enabled=yes
  when: jenkins_plugins_installation.changed
```