### PR TITLE
fix example playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ Changes made to the Jenkins init script; the default set of changes set the conf
   vars:
     jenkins_hostname: jenkins.example.com
   roles:
-    - role: geerlingguy.java
-      become: yes
     - role: geerlingguy.jenkins
       become: yes
 ```


### PR DESCRIPTION
`geerlingguy.java` is applied twice if `java_packages` parameter is passed.

And `geerlingguy.jenkins` works without explicit specification of `geerlingguy.java`.

`geerlingguy.java` should be removed from the example playbook.

## Example
playbook.yml
```yaml
- hosts: jenkins
  vars:
    jenkins_hostname: jenkins.example.com
  roles:
    - role: geerlingguy.java
      become: yes
      java_packages:
        - openjdk-8-jdk
    - role: geerlingguy.jenkins
      become: yes
```

result:
```
...

TASK [geerlingguy.java : Ensure Java is installed.] *********************************************************************************************************************************
ok: [192.168.33.10] => (item=[u'openjdk-8-jdk'])

...

TASK [geerlingguy.java : Ensure Java is installed.] *********************************************************************************************************************************
ok: [192.168.33.10] => (item=[u'openjdk-11-jdk'])

...
```

and jenkins doesn't start because it references `openjdk-11-jdk`...