### PR TITLE
Remove tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,6 @@ Default admin account credentials which will be created the first time Jenkins i
 
 Default admin password file which will be created the first time Jenkins is installed as /var/lib/jenkins/secrets/initialAdminPassword
 
-    jenkins_admin_token: ""
-
-A Jenkins API token (generated after installation) for [authenticated scripted clients](https://wiki.jenkins-ci.org/display/JENKINS/Authenticating+scripted+clients). You can use the admin token instead of a username and password for more convenient scripted access to Jenkins (e.g. for plugin management through this role).
-
-    jenkins_admin_token_file: ""
-
-A file (with full path) on the Jenkins server containing the admin token. If this variable is set in addition to the `jenkins_admin_token`, the contents of this file will overwrite the value of `jenkins_admin_token`.
-
     jenkins_jar_location: /opt/jenkins-cli.jar
 
 The location at which the `jenkins-cli.jar` jarfile will be kept. This is used for communicating with Jenkins via the CLI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,8 +25,6 @@ jenkins_plugins_install_dependencies: true
 jenkins_admin_username: admin
 jenkins_admin_password: admin
 jenkins_admin_password_file: ""
-jenkins_admin_token: ""
-jenkins_admin_token_file: ""
 
 jenkins_process_user: jenkins
 jenkins_process_group: "{{ jenkins_process_user }}"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -12,18 +12,6 @@
     jenkins_admin_password: "{{ adminpasswordfile['stdout'] | default(jenkins_admin_password) }}"
   no_log: true
 
-- name: Get Jenkins admin token from file.
-  slurp:
-    src: "{{ jenkins_admin_token_file }}"
-  register: admintokenfile
-  no_log: true
-  when: jenkins_admin_token_file != ""
-
-- name: Set Jenkins admin token fact.
-  set_fact:
-    jenkins_admin_token: "{{ admintokenfile['stdout'] | default(jenkins_admin_token) }}"
-  no_log: true
-
 # Update Jenkins so that plugin updates don't fail.
 - name: Create update directory
   file:
@@ -59,15 +47,4 @@
     with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
   with_items: "{{ jenkins_plugins }}"
   when: jenkins_admin_password != ""
-  notify: restart jenkins
-
-- name: Install Jenkins plugins using token.
-  jenkins_plugin:
-    name: "{{ item }}"
-    url_token: "{{ jenkins_admin_token }}"
-    updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
-    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
-    with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
-  with_items: "{{ jenkins_plugins }}"
-  when: jenkins_admin_token != ""
   notify: restart jenkins


### PR DESCRIPTION
jenkins_plugin modules does not support tokens so there is no point
attempting to use from there.

Fixes #205