### PR TITLE
fix for servers using satellite that with no internet access

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -17,6 +17,7 @@
   rpm_key:
     state: present
     key: "{{ jenkins_repo_key_url }}"
+  when: jenkins_repo_key_url != ''
 
 - name: Download specific Jenkins version.
   get_url:


### PR DESCRIPTION
only attempted to install an RPM key if one is defined.