### PR TITLE
Skip GPG key when not installing the repo

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -17,6 +17,7 @@
   rpm_key:
     state: present
     key: "{{ jenkins_repo_key_url }}"
+  when: jenkins_repo_url != ''
 
 - name: Download specific Jenkins version.
   get_url:


### PR DESCRIPTION
If you elect to not install the repo, trying to install the GPG key is a waste, and worse, in environments where you skip the repo because you wish to directly download from an HTTP mirror, trying to install the (blocked off internet) gpg key location will fail the play.