### PR TITLE
Usage statistics option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,8 @@ jenkins_admin_password_file: ""
 jenkins_process_user: jenkins
 jenkins_process_group: "{{ jenkins_process_user }}"
 
+jenkins_disable_usage_statistics: true
+
 jenkins_init_changes:
   - option: "JENKINS_ARGS"
     value: "--prefix={{ jenkins_url_prefix }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,4 +9,15 @@
     owner: "{{ jenkins_process_user }}"
     group: "{{ jenkins_process_group }}"
     mode: 0775
+  listen: "configure jenkins settings"
   register: jenkins_users_config
+
+- name: configure base settings
+  template:
+    src: collect-statistics.groovy
+    dest: "{{ jenkins_home }}/init.groovy.d/collect-statistics.groovy"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0775
+  when: "{{ jenkins_disable_usage_statistics }}"
+  listen: "configure jenkins settings"

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -35,10 +35,10 @@
     deb: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
     state: present
   when: jenkins_version is defined and specific_version.stat.exists
-  notify: configure default users
+  notify: "configure jenkins settings"
 
 - name: Ensure Jenkins is installed.
   apt:
     name: jenkins
     state: "{{ jenkins_package_state }}"
-  notify: configure default users
+  notify: "configure jenkins settings"

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -35,10 +35,10 @@
     name: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     state: present
   when: jenkins_version is defined and specific_version.stat.exists
-  notify: configure default users
+  notify: "configure jenkins settings"
 
 - name: Ensure Jenkins is installed.
   package:
     name: jenkins
     state: "{{ jenkins_package_state }}"
-  notify: configure default users
+  notify: "configure jenkins settings"

--- a/templates/collect-statistics.groovy
+++ b/templates/collect-statistics.groovy
@@ -1,3 +1,5 @@
+import jenkins.model.Jenkins
+
 def instance = Jenkins.getInstance()
 
 if(instance.isUsageStatisticsCollected()) {

--- a/templates/collect-statistics.groovy
+++ b/templates/collect-statistics.groovy
@@ -1,0 +1,6 @@
+def instance = Jenkins.getInstance()
+
+if(instance.isUsageStatisticsCollected()) {
+    instance.setNoUsageStatistics(true)
+    instance.save()
+}


### PR DESCRIPTION
Hello,

Not every organization allows the transmission of such statistics from it's systems. So we've added an option to disable the collection of usage statistics to the jenkins role.


Regards,
Marcus