### PR TITLE
added retries to the get_url and jenkins_plug tasks

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -29,6 +29,10 @@
     group: jenkins
     mode: 0440
   changed_when: false
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
 
 - name: Remove first and last line from json file
   replace:
@@ -50,3 +54,7 @@
   when: jenkins_admin_password != ""
   notify: restart jenkins
   tags: ['skip_ansible_lint']
+  register: plugin_result
+  until: plugin_result is success
+  retries: 3
+  delay: 2


### PR DESCRIPTION
Sometimes the plugin downloads can timeout for myriad reasons. plus, it is "linty" to have retries on anything that fetches external files