### PR TITLE
Add jenkins_updates_url variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Use `latest` to ensure all plugins are running the most up-to-date version.
 
 Number of seconds after which a new copy of the update-center.json file is downloaded. Set it to 0 if no cache file should be used.
 
+   jenkins_updates_url: "https://updates.jenkins.io" 
+
+The URL where to find updates for plugins. 
+
     jenkins_plugin_timeout: 30
 
 The server connection timeout, in seconds, when installing Jenkins plugins.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ jenkins_plugins_state: present
 jenkins_plugin_updates_expiration: 86400
 jenkins_plugin_timeout: 30
 jenkins_plugins_install_dependencies: true
+jenkins_updates_url: "https://updates.jenkins.io"
 
 jenkins_admin_username: admin
 jenkins_admin_password: admin

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -44,6 +44,7 @@
     state: "{{ jenkins_plugins_state }}"
     timeout: "{{ jenkins_plugin_timeout }}"
     updates_expiration: "{{ jenkins_plugin_updates_expiration }}"
+    updates_url: "{{ jenkins_updates_url }}"
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
     with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
   with_items: "{{ jenkins_plugins }}"


### PR DESCRIPTION
I added this variable and set it to "https://updates.jenkins.io" since, the default one "https://updates.jenkins-ci.org" has invalid certificate.
