### PR TITLE
Add unauthenticated proxy options.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,10 @@ jenkins_init_changes:
     value: "--prefix={{ jenkins_url_prefix }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
+
+# If Jenkins is behind a proxy, configure this.
+jenkins_proxy_host: ""
+jenkins_proxy_port: ""
+jenkins_proxy_noproxy:
+  - "127.0.0.1"
+  - "localhost"

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -57,6 +57,18 @@
     group: "{{ jenkins_process_group }}"
     mode: 0775
 
+- name: Configure proxy config for Jenkins
+  template:
+    src: proxy.xml
+    dest: "{{ jenkins_home }}/proxy.xml"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0664
+  register: jenkins_proxy_config
+  when:
+    - jenkins_proxy_host | length > 0
+    - jenkins_proxy_port | length > 0
+
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers
 
@@ -66,4 +78,5 @@
     (jenkins_users_config is defined and jenkins_users_config.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
+    or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)
   tags: ['skip_ansible_lint']

--- a/templates/proxy.xml
+++ b/templates/proxy.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<proxy>
+  <name>{{ jenkins_proxy_host }}</name>
+  <port>{{ jenkins_proxy_port}}</port>
+  <noProxyHost>{{ jenkins_proxy_noproxy | join(',') }}</noProxyHost>
+  <secretPassword></secretPassword>
+</proxy>


### PR DESCRIPTION
Jenkins breaks when it sits behind a proxy unconfigured.
In our particular use case plugins will not install correctly.
This PR adds parameters/config to allow a proxy to be configured.

This was previously raised by a colleague in PR207
https://github.com/geerlingguy/ansible-role-jenkins/pull/207