### PR TITLE
Add support for proxy configurations

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,11 @@ jenkins_init_changes:
     value: "--prefix={{ jenkins_url_prefix }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
+
+# If Jenkins is behind a proxy, configure this.
+# jenkins_proxy_host: ""
+# jenkins_proxy_port: ""
+# jenkins_proxy_secret: ""
+jenkins_proxy_noproxy:
+  - "127.0.0.1"
+  - "localhost"

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -34,6 +34,14 @@
   retries: 3
   delay: 2
 
+- name: Configure hudson.model.UpdateCenter.xml updates url.
+  template:
+    src: hudson.model.UpdateCenter.xml.j2
+    dest: "{{ jenkins_home }}/hudson.model.UpdateCenter.xml"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0640
+
 - name: Remove first and last line from json file.
   replace:
     path: "{{ jenkins_home }}/updates/default.json"

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -57,6 +57,18 @@
     group: "{{ jenkins_process_group }}"
     mode: 0775
 
+- name: Configure proxy config for Jenkins
+  template:
+    src: proxy.xml.j2
+    dest: "{{ jenkins_home }}/proxy.xml"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0664
+  register: jenkins_proxy_config
+  when:
+    - jenkins_proxy_host is defined
+    - jenkins_proxy_port is defined
+
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers
 
@@ -66,4 +78,5 @@
     (jenkins_users_config is defined and jenkins_users_config.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
+    or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)
   tags: ['skip_ansible_lint']

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -10,6 +10,12 @@
   apt_key:
     url: "{{ jenkins_repo_key_url }}"
     state: present
+  when: "'HTTP_PROXY' not in ansible_env"
+
+- name: Add Jenkins apt repository key behind a proxy.
+  command: |
+    apt-key adv --keyserver-options http-proxy={{ ansible_env.HTTP_PROXY }}  --fetch-keys {{ jenkins_repo_key_url|quote }}
+  when: "'HTTP_PROXY' in ansible_env"
 
 - name: Add Jenkins apt repository.
   apt_repository:

--- a/templates/hudson.model.UpdateCenter.xml.j2
+++ b/templates/hudson.model.UpdateCenter.xml.j2
@@ -1,0 +1,7 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<sites>
+  <site>
+    <id>default</id>
+    <url>{{ jenkins_updates_url }}/update-center.json</url>
+  </site>
+</sites>

--- a/templates/proxy.xml.j2
+++ b/templates/proxy.xml.j2
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<proxy>
+  <name>{{ jenkins_proxy_host }}</name>
+  <port>{{ jenkins_proxy_port}}</port>
+  <noProxyHost>{{ jenkins_proxy_noproxy | join(',') }}</noProxyHost>
+  <secretPassword>{{ jenkins_proxy_secret }}</secretPassword>
+</proxy>


### PR DESCRIPTION
Following the works on #256  and #28.

This PR adds:

- Setup the update center configuration `hudson.model.UpdateCenter.xml` to persist the URL change, required when you need to whitelist the FQDN of the Jenkins mirror avoiding any 30x redirection.
- Setup the proxy configuration by updating the `proxy.xml` file
- Add some defaults for the `jenkins_proxy_*` related vars
- For Debian based systems, replaces `apt_key` command with a `curl` when behind a proxy to avoid `apt_key` ansible module issue reported in https://github.com/ansible/ansible/issues/42534 / https://github.com/ansible/ansible/pull/42536.

