### PR TITLE
Added Firewall configuration to CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Used for setting a URL prefix for your Jenkins installation. The option is added
     jenkins_connection_delay: 5
     jenkins_connection_retries: 60
 
+(Optional) Default to false, if you need to configure the remote host firewall (like firewalld by default in CentOS) to open the `jenkins_http_port` so it's accesible from outside the host.
+	
+	jenkins_firewall_configure: true (default is false)
+
 Amount of time and number of times to wait when connecting to Jenkins after initial startup, to verify that Jenkins is running. Total time to wait = `delay` * `retries`, so by default this role will wait up to 300 seconds before timing out.
 
     # For RedHat/CentOS (role default):

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ jenkins_init_changes:
     value: "--prefix={{ jenkins_url_prefix }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
+
+jenkins_firewall_configure: false

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -46,7 +46,7 @@
 
 - name: Configure firewalld
   firewalld:
-    port: "{{ jenkins_http_port }}"
+    port: "{{ jenkins_http_port }}/tcp"
     permanent: yes
     immediate: yes
     state: enabled

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -43,3 +43,11 @@
     name: jenkins
     state: "{{ jenkins_package_state }}"
   notify: configure default users
+
+- name: Configure firewalld
+  firewalld:
+    port: "{{ jenkins_http_port }}"
+    permanent: yes
+    immediate: yes
+    state: enabled
+  when: jenkins_firewall_configure is defined and jenkins_firewall_configure


### PR DESCRIPTION
Add a new variable called `jenkins_firewall_configure` with default to false. If true, ATM, it configures Firewalld as part of the RedHat setup file.

Pending to include for others firewalls: identification of the firewall used in the box (and enabled) and open the port on each of them.