### PR TITLE
#276: Allow jenkins_java_options to be specified as a list

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -14,8 +14,14 @@
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     insertafter: '^{{ item.option }}='
-    regexp: '^{{ item.option }}=\"\${{ item.option }} '
-    line: '{{ item.option }}="${{ item.option }} {{ item.value }}"'
+    regexp: '^{{ item.option }}="\${{ item.option }} '
+    line: >-
+      '{{ item.option }}="${{ item.option }} '
+      '{% if item.value is string %}'
+      '{{ item.value }}'
+      '{% else %}'
+      '{{ item.value | join(" ") }}'
+      '{% endif %}"'
     state: present
   with_items: "{{ jenkins_init_changes }}"
   register: jenkins_init_prefix


### PR DESCRIPTION
Hi @geerlingguy,

Being able to specify jenkins_java_options as a list makes my playbook much easier to read and see what is being set.  Please let me know if there are any issues with this PR.

Note, I have retained the existing behaviour if `jenkins_java_options` is specified as a string

Thanks,
Neil