### PR TITLE
added retries for ext

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -11,6 +11,10 @@
   apt_key:
     url: "{{ jenkins_repo_key_url }}"
     state: present
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
 
 - name: Add Jenkins apt repository.
   apt_repository:
@@ -18,12 +22,20 @@
     state: present
     update_cache: true
   when: jenkins_repo_url != ""
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
   tags: ['skip_ansible_lint']
 
 - name: Download specific Jenkins version.
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins_{{ jenkins_version }}_all.deb"
     dest: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
   when: jenkins_version is defined
 
 - name: Check if we downloaded a specific version of Jenkins.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,6 +12,10 @@
     url: "{{ jenkins_repo_url }}"
     dest: /etc/yum.repos.d/jenkins.repo
   when: jenkins_repo_url != ""
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
   tags: ['skip_ansible_lint']
 
 - name: Add Jenkins repo GPG key.
@@ -19,12 +23,20 @@
     state: present
     key: "{{ jenkins_repo_key_url }}"
   when: jenkins_repo_url != ''
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
 
 - name: Download specific Jenkins version.
   get_url:
     url: "{{ jenkins_pkg_url }}/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     dest: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
   when: jenkins_version is defined
+  register: get_result
+  until: get_result is success
+  retries: 3
+  delay: 2
 
 - name: Check if we downloaded a specific version of Jenkins.
   stat:


### PR DESCRIPTION
Fixes #274
Replaces #275 

Adds the register->until->retry methodology to the external downloads for the Jenkins install components.

Tested via Travis/Molecule