### PR TITLE
#276 Allow jenkins_java_options to be specified as a list

### DIFF
--- a/molecule/default/playbook-multiline-jenkins-java-options.yml
+++ b/molecule/default/playbook-multiline-jenkins-java-options.yml
@@ -1,0 +1,30 @@
+---
+- name: Converge
+  hosts: all
+  become: true
+
+  vars:
+    jenkins_version: "1.644"
+    jenkins_java_options:
+      - "-Xmx1536m"
+      - "-Xms768m"
+
+  roles:
+    - geerlingguy.java
+    - geerlingguy.jenkins
+
+  post_tasks:
+    - name: Check installed version of Jenkins.
+      command: grep "{{ jenkins_java_options_env_var }}" "{{ jenkins_init_file }}"
+      args:
+        warn: false
+      changed_when: false
+      register: jenkins_grepped_java_options
+      tags: ['skip_ansible_lint']
+
+    - name: Print found java options
+      debug: var=jenkins_grepped_java_options
+
+    - name: Fail if our init addition isn't in the file
+      fail:
+      when: "'-Xmx1536m' not in jenkins_grepped_java_options.stdout"

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -14,8 +14,14 @@
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     insertafter: '^{{ item.option }}='
-    regexp: '^{{ item.option }}=\"\${{ item.option }} '
-    line: '{{ item.option }}="${{ item.option }} {{ item.value }}"'
+    regexp: '^{{ item.option }}="\${{ item.option }} '
+    line: >
+      {{ item.option }}="${{ item.option }}
+      {% if item.value is string %}
+      {{ item.value }}
+      {% else %}
+      {{ item.value | join(" ") }}
+      {% endif %}"
     state: present
   with_items: "{{ jenkins_init_changes }}"
   register: jenkins_init_prefix


### PR DESCRIPTION
Hi @geerlingguy,

Being able to specify jenkins_java_options as a list makes my playbook much easier to read and see what is being set. Please let me know if there are any issues with this PR.

Note, I have retained the existing behaviour if `jenkins_java_options` is specified as a string, so existing playbooks shouldn't be affected.

Thanks,
Neil