### PR TITLE
#283: Install correct libselinux RPM for the python version

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -3,9 +3,20 @@
   package:
     name:
       - curl
-      - libselinux-python
       - initscripts
     state: present
+
+- name: Install appropriate selinux library (python 3)
+  package:
+    name: python3-libselinux
+    state: present
+  when: ansible_python['version']['major'] >= 3
+
+- name: Install appropriate selinux library (python 2)
+  package:
+    name: libselinux-python
+    state: present
+  when: ansible_python['version']['major'] < 3
 
 - name: Ensure Jenkins repo is installed.
   get_url:


### PR DESCRIPTION
Hi @geerlingguy,

I need to use the module to manage jenkins on different servers.  Some have python 2, others have python 3.

I know that ansible are trying to remove the requirement for libselinux, but until then, we need to cope with both.

Please can this be merged.

Thanks,
Neil