### PR TITLE
Add jenkins_prefer_lts variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,34 @@ Used for setting a URL prefix for your Jenkins installation. The option is added
 
 Amount of time and number of times to wait when connecting to Jenkins after initial startup, to verify that Jenkins is running. Total time to wait = `delay` * `retries`, so by default this role will wait up to 300 seconds before timing out.
 
-    # For RedHat/CentOS (role default):
-    jenkins_repo_url: https://pkg.jenkins.io/redhat/jenkins.repo
-    jenkins_repo_key_url: https://pkg.jenkins.io/redhat/jenkins.io.key
-    # For Debian (role default):
-    jenkins_repo_url: deb https://pkg.jenkins.io/debian binary/
-    jenkins_repo_key_url: https://pkg.jenkins.io/debian/jenkins.io.key
+By default, this role will install the latest version of Jenkins using the official repositories according to the platform. You can install the current LTS version instead by setting `jenkins_prefer_lts: true`.
 
-This role will install the latest version of Jenkins by default (using the official repositories as listed above). You can override these variables (use the correct set for your platform) to install the current LTS version instead:
+The default repositories can be overridden as needed.
 
-    # For RedHat/CentOS LTS:
-    jenkins_repo_url: https://pkg.jenkins.io/redhat-stable/jenkins.repo
-    jenkins_repo_key_url: https://pkg.jenkins.io/redhat-stable/jenkins.io.key
-    # For Debian/Ubuntu LTS:
-    jenkins_repo_url: deb https://pkg.jenkins.io/debian-stable binary/
-    jenkins_repo_key_url: https://pkg.jenkins.io/debian-stable/jenkins.io.key
+```yaml
+# For RedHat/CentOS (role default):
+jenkins_repo_url: >-
+  {{
+     'https://pkg.jenkins.io/redhat-stable/jenkins.repo' if jenkins_prefer_lts | bool else
+     'https://pkg.jenkins.io/redhat/jenkins.repo'
+  }}
+jenkins_repo_key_url: >-
+  {{
+     'https://pkg.jenkins.io/redhat-stable/jenkins.io.key' if jenkins_prefer_lts | bool else
+     'https://pkg.jenkins.io/redhat/jenkins.io.key'
+  }}
+# For Debian/Ubuntu (role default):
+jenkins_repo_url: >-
+  {{
+     'deb https://pkg.jenkins.io/debian-stable binary/' if jenkins_prefer_lts | bool else
+     'deb https://pkg.jenkins.io/debian binary/'
+  }}
+jenkins_repo_key_url: >-
+  {{
+     'https://pkg.jenkins.io/debian-stable/jenkins.io.key' if jenkins_prefer_lts | bool else
+     'https://pkg.jenkins.io/debian/jenkins.io.key'
+  }}
+```
 
 It is also possible stop the repo file being added by setting  `jenkins_repo_url: ''`. This is useful if, for example, you sign your own packages or run internal package management (e.g. Spacewalk).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@
 # Change this to `latest` to update Jenkins if a newer version is available.
 jenkins_package_state: present
 
+jenkins_prefer_lts: false
+
 jenkins_connection_delay: 5
 jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,14 @@
 ---
-__jenkins_repo_url: deb https://pkg.jenkins.io/debian binary/
-__jenkins_repo_key_url: https://pkg.jenkins.io/debian/jenkins.io.key
+__jenkins_repo_url: >-
+  {{
+     'deb https://pkg.jenkins.io/debian-stable binary/' if jenkins_prefer_lts | bool else
+     'deb https://pkg.jenkins.io/debian binary/'
+  }}
+__jenkins_repo_key_url: >-
+  {{
+     'https://pkg.jenkins.io/debian-stable/jenkins.io.key' if jenkins_prefer_lts | bool else
+     'https://pkg.jenkins.io/debian/jenkins.io.key'
+  }}
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,14 @@
 ---
-__jenkins_repo_url: https://pkg.jenkins.io/redhat/jenkins.repo
-__jenkins_repo_key_url: https://pkg.jenkins.io/redhat/jenkins.io.key
+__jenkins_repo_url: >-
+  {{
+     'https://pkg.jenkins.io/redhat-stable/jenkins.repo' if jenkins_prefer_lts | bool else
+     'https://pkg.jenkins.io/redhat/jenkins.repo'
+  }}
+__jenkins_repo_key_url: >-
+  {{
+     'https://pkg.jenkins.io/redhat-stable/jenkins.io.key' if jenkins_prefer_lts | bool else
+     'https://pkg.jenkins.io/redhat/jenkins.io.key'
+  }}
 __jenkins_pkg_url: https://pkg.jenkins.io/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT


### PR DESCRIPTION
It's convenient to be able to prefer LTS over weekly releases without having to set two variables to platform-specific values in inventories or playbooks.