### PR TITLE
Remove strict dependency on geerlingguy.java role

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,17 +119,18 @@ If you are running Jenkins behind a proxy server, configure these options approp
 
 ## Dependencies
 
-  - geerlingguy.java
+None.
 
 ## Example Playbook
 
 ```yaml
 - hosts: jenkins
+  become: true
   vars:
     jenkins_hostname: jenkins.example.com
   roles:
+    - role: geerlingguy.java
     - role: geerlingguy.jenkins
-      become: yes
 ```
 
 ## License

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,5 @@
 ---
-dependencies:
-  - geerlingguy.java
+dependencies: []
 
 galaxy_info:
   author: geerlingguy


### PR DESCRIPTION
Fixes #195. There's no way to maintain compatibility, but I updated the documentation. Semantically, this change my justify a bump in the major version number.