### PR TITLE
Fixed slurp of jenkins_admin_password_file

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -8,10 +8,17 @@
   when: jenkins_admin_password_file | default(false)
   tags: ['skip_ansible_lint']
 
-- name: Set Jenkins admin password fact.
+- name: Set Jenkins admin password fact from variable.
   set_fact:
-    jenkins_admin_password: "{{ adminpasswordfile['stdout'] | default(jenkins_admin_password) }}"
-  no_log: true
+    jenkins_admin_password: "{{ jenkins_admin_password }}"
+  no_log: false
+  when: jenkins_admin_password_file == false
+
+- name: Set Jenkins admin password fact from file.
+  set_fact:
+    jenkins_admin_password: "{{ adminpasswordfile['content'] | b64decode }}"
+  no_log: false
+  when: jenkins_admin_password_file
 
 # Update Jenkins so that plugin updates don't fail.
 - name: Create Jenkins updates directory.


### PR DESCRIPTION
I fixed the slurp of the jenkins_admin_password_file.

Replaced `adminpasswordfile['stdout']` with `adminpasswordfile['content'] | b64decode`.

stdout is not existing.