### PR TITLE
Principle of Least Privilege applied to ansible

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,9 @@
 ---
 - name: restart jenkins
   become: True
-  service: name=jenkins state=restarted
+  service:
+    name: jenkins
+    state: restarted
 
 - name: configure default users
   become: True

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,10 @@
 ---
 - name: restart jenkins
+  become: True
   service: name=jenkins state=restarted
 
 - name: configure default users
+  become: True
   template:
     src: basic-security.groovy.j2
     dest: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"

--- a/molecule/default/java-8.yml
+++ b/molecule/default/java-8.yml
@@ -1,7 +1,9 @@
 ---
 # Debian.
 - name: Update apt cache.
-  apt: update_cache=true cache_valid_time=600
+  apt:
+    update_cache: true
+    cache_valid_time: 600
   when: ansible_os_family == 'Debian'
   changed_when: false
 

--- a/molecule/default/playbook-jenkins-version.yml
+++ b/molecule/default/playbook-jenkins-version.yml
@@ -20,7 +20,8 @@
       tags: ['skip_ansible_lint']
 
     - name: Print installed Jenkins package information.
-      debug: var=jenkins_rpm_version
+      debug:
+        var: jenkins_rpm_version
 
     - name: Fail if version doesn't match what we wanted.
       fail:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,10 @@
 # Make sure Jenkins starts, then configure Jenkins.
 - name: Ensure Jenkins is started and runs on startup.
   become: True
-  service: name=jenkins state=started enabled=yes
+  service:
+    name: jenkins
+    state: started
+    enabled: yes
 
 - name: Wait for Jenkins to start up before proceeding.
   uri:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
 
 # Make sure Jenkins starts, then configure Jenkins.
 - name: Ensure Jenkins is started and runs on startup.
+  become: True
   service: name=jenkins state=started enabled=yes
 
 - name: Wait for Jenkins to start up before proceeding.
@@ -49,6 +50,7 @@
   check_mode: false
 
 - name: Get the jenkins-cli jarfile from the Jenkins server.
+  become: True
   get_url:
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}/jnlpJars/jenkins-cli.jar"
     dest: "{{ jenkins_jar_location }}"
@@ -59,6 +61,7 @@
   check_mode: false
 
 - name: Remove Jenkins security init scripts after first startup.
+  become: True
   file:
     path: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
     state: absent

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -41,7 +41,9 @@
 
 - name: Immediately restart Jenkins on init config changes.
   become: True
-  service: name=jenkins state=restarted
+  service:
+    name: jenkins
+    state: restarted
   when: jenkins_init_prefix.changed
   tags: ['skip_ansible_lint']
 
@@ -81,7 +83,9 @@
 
 - name: Immediately restart Jenkins on http or user changes.
   become: True
-  service: name=jenkins state=restarted
+  service:
+    name: jenkins
+    state: restarted
   when: >
     (jenkins_users_config is defined and jenkins_users_config.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -11,6 +11,7 @@
   when: not jenkins_init_file_stat.stat.exists
 
 - name: Modify variables in init file.
+  become: True
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     insertafter: '^{{ item.option }}='
@@ -21,6 +22,7 @@
   register: jenkins_init_prefix
 
 - name: Ensure jenkins_home {{ jenkins_home }} exists.
+  become: True
   file:
     path: "{{ jenkins_home }}"
     state: directory
@@ -30,6 +32,7 @@
     follow: true
 
 - name: Set the Jenkins home directory.
+  become: True
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     regexp: '^JENKINS_HOME=.*'
@@ -37,11 +40,13 @@
   register: jenkins_home_config
 
 - name: Immediately restart Jenkins on init config changes.
+  become: True
   service: name=jenkins state=restarted
   when: jenkins_init_prefix.changed
   tags: ['skip_ansible_lint']
 
 - name: Set HTTP port in Jenkins config.
+  become: True
   lineinfile:
     backrefs: true
     dest: "{{ jenkins_init_file }}"
@@ -50,6 +55,7 @@
   register: jenkins_http_config
 
 - name: Create custom init scripts directory.
+  become: True
   file:
     path: "{{ jenkins_home }}/init.groovy.d"
     state: directory
@@ -58,6 +64,7 @@
     mode: 0775
 
 - name: Configure proxy config for Jenkins
+  become: True
   template:
     src: proxy.xml
     dest: "{{ jenkins_home }}/proxy.xml"
@@ -73,6 +80,7 @@
   meta: flush_handlers
 
 - name: Immediately restart Jenkins on http or user changes.
+  become: True
   service: name=jenkins state=restarted
   when: >
     (jenkins_users_config is defined and jenkins_users_config.changed)

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure dependencies are installed.
+  become: True
   package:
     name:
       - curl
@@ -8,12 +9,14 @@
     state: present
 
 - name: Ensure Jenkins repo is installed.
+  become: True
   get_url:
     url: "{{ jenkins_repo_url }}"
     dest: /etc/yum.repos.d/jenkins.repo
   when: jenkins_repo_url | default(false)
 
 - name: Add Jenkins repo GPG key.
+  become: True
   rpm_key:
     state: present
     key: "{{ jenkins_repo_key_url }}"
@@ -32,6 +35,7 @@
   when: jenkins_version is defined
 
 - name: Install our specific version of Jenkins.
+  become: True
   package:
     name: "/tmp/jenkins-{{ jenkins_version }}-1.1.noarch.rpm"
     state: present
@@ -39,6 +43,7 @@
   notify: configure default users
 
 - name: Ensure Jenkins is installed.
+  become: True
   package:
     name: jenkins
     state: "{{ jenkins_package_state }}"


### PR DESCRIPTION
Only use become for tasks that need it instead of giving to the whole role or playbook.

Only tested/check for the setup I'm using so other tasks might also need to be changed, or having become removed from. Which was Vagrant, VirtualBox and Centos 7.

Also some reformat of single line statements into multi line statements.