### PR TITLE
#304: Configure Jenkins' updates URL

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -22,23 +22,28 @@
     group: jenkins
     mode: 0755
 
-- name: Download current plugin updates from Jenkins update site.
-  get_url:
-    url: "{{ jenkins_updates_url }}/update-center.json"
-    dest: "{{ jenkins_home }}/updates/default.json"
-    owner: jenkins
-    group: jenkins
-    mode: 0440
-  changed_when: false
-  register: get_result
-  until: get_result is success
-  retries: 3
-  delay: 2
+- name: Point jenkins at the given updates URL
+  jenkins_script:
+    script: |
+      import hudson.model.UpdateCenter
+      import hudson.model.UpdateSite
+      import hudson.util.PersistedList
+      import jenkins.model.Jenkins
 
-- name: Remove first and last line from json file.
-  replace:  # noqa 208
-    path: "{{ jenkins_home }}/updates/default.json"
-    regexp: "1d;$d"
+      url = "${site}"
+      PersistedList < UpdateSite > sites = Jenkins.getInstance().getUpdateCenter().getSites()
+      for (UpdateSite s: sites) {
+        if (s.getId().equals(UpdateCenter.ID_DEFAULT))
+          sites.remove(s)
+      }
+      UpdateSite site = new UpdateSite(UpdateCenter.ID_DEFAULT, url)
+      sites.add(site)
+      site.updateDirectlyNow(false)
+    args:
+      site: "{{ jenkins_updates_url }}/update-center.json"
+    url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
+    user: "{{ jenkins_admin_username }}"
+    password: "{{ jenkins_admin_password }}"
 
 - name: Install Jenkins plugins using password.
   jenkins_plugin:


### PR DESCRIPTION
Some corporate firewalls restrict outbound traffic.  Jenkins default uses a
mirror system where the list of possible endpoints that updates and plugins may
be downloaded from is changeable with little or no notice.  Maintaining the
firewall's permitted URL list when the mirror list changes may therefore be
problematic, requiring change tickets etc.

Whilst we did have the ability to download the updates list from the specified
mirror, when jenkins was asked to install a given plugin, the list still
referred to updates.jenkins-ci.org, which might then fail.  This change permits
a modified version of the updates file to be used with a fixed mirror in it to
safely negotiate such a corporate firewall.

Fixes #304 