### PR TITLE
Add Jenkins process groups variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ jenkins_admin_password_file: ""
 
 jenkins_process_user: jenkins
 jenkins_process_group: "{{ jenkins_process_user }}"
+jenkins_process_groups: []
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -53,6 +53,12 @@
     mode: 0644
   register: jenkins_http_config
 
+- name: Ensure Jenkins process user is created.
+  user:
+    name: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    groups: "{{ jenkins_process_groups }}"
+
 - name: Create custom init scripts directory.
   file:
     path: "{{ jenkins_home }}/init.groovy.d"


### PR DESCRIPTION
Sometime we need that the process user is in a specific group. So I suggest this merge request to add the groups variable.

For example for us, the jenkins user need to be in the [glowroot](https://glowroot.org/) group.