### PR TITLE
Adds the ability to enable proxy compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Changes made to the Jenkins init script; the default set of changes set the conf
 
 If you are running Jenkins behind a proxy server, configure these options appropriately. Otherwise Jenkins will be configured with a direct Internet connection.
 
+    jenkins_proxy_compatibility: false
+
+If you cannot control your client IP  and it is different that what is stored in your cookie (going through a 3rd party proxy that has multiple client IPs) you will have CSRF issues. To workaround that you might need to [enable proxy compatibility mode](https://www.jenkins.io/doc/book/managing/security/#cross-site-request-forgery) by setting the jenkins_proxy_compatibility option to true.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,3 +49,4 @@ jenkins_proxy_port: ""
 jenkins_proxy_noproxy:
   - "127.0.0.1"
   - "localhost"
+jenkins_proxy_compatibility: false

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -73,6 +73,22 @@
     - jenkins_proxy_host | length > 0
     - jenkins_proxy_port | length > 0
 
+- name: Enable proxy compatibility mode
+  lineinfile:
+    dest: "{{ jenkins_home }}/config.xml"
+    regexp: '\S*<excludeClientIPFromCrumb>false<\/excludeClientIPFromCrumb>'
+    line: '<excludeClientIPFromCrumb>true</excludeClientIPFromCrumb>'
+  register: jenkins_proxy_compatibility_config
+  when: jenkins_proxy_compatibility
+
+- name: Disable proxy compatibility mode
+  lineinfile:
+    dest: "{{ jenkins_home }}/config.xml"
+    regexp: '\S*<excludeClientIPFromCrumb>true<\/excludeClientIPFromCrumb>'
+    line: '<excludeClientIPFromCrumb>false</excludeClientIPFromCrumb>'
+  register: jenkins_proxy_compatibility_config
+  when: jenkins_proxy_compatibility|bool == false
+
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers
 
@@ -83,4 +99,5 @@
     or (jenkins_http_config is defined and jenkins_http_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
     or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)
+    or (jenkins_proxy_compatibility_config and jenkins_proxy_compatibility_config.changed)
   tags: ['skip_ansible_lint']


### PR DESCRIPTION
In some cases it is not possible to provide proxy configuration because
it is a 3rd party that is out of your control or you are using some port
forwarding service that has a block of IPs (multiple proxy IPs). Jenkins
provides a proxy compatibility mode that excludes the client IP when
creating the CSRF token. This option needs to be exposed via the role
as it cannot be set via the web browser after completing setup because
any attempt to change the config will fail the CSRF check.

More information on this option - https://www.jenkins.io/doc/book/managing/security/#cross-site-request-forgery