### PR TITLE
Force the apt installation of the downloaded .deb

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -36,6 +36,7 @@
   apt:
     deb: "/tmp/jenkins_{{ jenkins_version }}_all.deb"
     state: present
+    force: yes
   when: jenkins_version is defined and specific_version.stat.exists
   notify: configure default users
 


### PR DESCRIPTION
Force the apt installation of the downloaded .deb.

This fixes https://github.com/geerlingguy/ansible-role-jenkins/issues/218.