### PR TITLE
Fix task to remove first and last line of json

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -36,9 +36,13 @@
   delay: 2
 
 - name: Remove first and last line from json file.
-  replace:  # noqa 208
+  lineinfile:
     path: "{{ jenkins_home }}/updates/default.json"
-    regexp: "1d;$d"
+    regexp: '^{{ item }}'
+    state: absent
+  with_items:
+    - "updateCenter.post\\("
+    - "\\);"
 
 - name: Install Jenkins plugins using password.
   jenkins_plugin:


### PR DESCRIPTION
I was finding it weird that sometimes ansible would install the plugins, but most of the times it wasn't.

The replaced task was not removing the lines correctly, maybe because of the `regex`, but I found it more convenient to use the `lineinfile` module.

The **lines to remove are predictable** and we can try to remove them only when they exist, which IMO is better than removing the first and last every time.

Issues reference:

* https://github.com/geerlingguy/ansible-role-jenkins/issues/312
* https://github.com/geerlingguy/ansible-role-jenkins/issues/315
* https://github.com/geerlingguy/ansible-role-jenkins/issues/310