### PR TITLE
Switched to using groovy scripts to initialize

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -22,23 +22,17 @@
     group: jenkins
     mode: 0755
 
-- name: Download current plugin updates from Jenkins update site.
-  get_url:
-    url: "{{ jenkins_updates_url }}/update-center.json"
-    dest: "{{ jenkins_home }}/updates/default.json"
-    owner: jenkins
-    group: jenkins
-    mode: 0440
-  changed_when: false
-  register: get_result
-  until: get_result is success
-  retries: 3
-  delay: 2
+- name: Create groovy script to refresh update center
+  set_fact:
+    update_center: |
+      import hudson.model.UpdateCenter
+      Jenkins.instance.pluginManager.doCheckUpdatesServer()
 
-- name: Remove first and last line from json file.
-  replace:  # noqa 208
-    path: "{{ jenkins_home }}/updates/default.json"
-    regexp: "1d;$d"
+- name: Ensure Updates Center is up-to-date
+  jenkins_script:
+    script: "{{ update_center }}"
+    args:
+      jenkins_mode: Node.Mode.EXCLUSIVE
 
 - name: Install Jenkins plugins using password.
   jenkins_plugin:


### PR DESCRIPTION
Exiting method fails because jenkins automatically deletes the
update file

With a groovy script we're using internal jenkins calls which
should be more future-proof