### PR TITLE
Supports username/password for proxy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,6 +46,8 @@ jenkins_init_changes:
 # If Jenkins is behind a proxy, configure this.
 jenkins_proxy_host: ""
 jenkins_proxy_port: ""
+jenkins_proxy_user: ""
+jenkins_proxy_pass: ""
 jenkins_proxy_noproxy:
   - "127.0.0.1"
   - "localhost"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,5 +63,10 @@
     path: "{{ jenkins_home }}/init.groovy.d/basic-security.groovy"
     state: absent
 
+- name: Remove Jenkins proxy init scripts after first startup.
+  file:
+    path: "{{ jenkins_home }}/init.groovy.d/proxy-configuration.groovy"
+    state: absent
+
 # Update Jenkins and install configured plugins.
 - include_tasks: plugins.yml

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -61,17 +61,13 @@
     group: "{{ jenkins_process_group }}"
     mode: 0775
 
-- name: Configure proxy config for Jenkins
+- name: Ensure proxy is configured on startup.
   template:
-    src: proxy.xml
-    dest: "{{ jenkins_home }}/proxy.xml"
+    src: proxy-configuration.groovy.j2
+    dest: "{{ jenkins_home }}/init.groovy.d/proxy-configuration.groovy"
     owner: "{{ jenkins_process_user }}"
     group: "{{ jenkins_process_group }}"
-    mode: 0664
-  register: jenkins_proxy_config
-  when:
-    - jenkins_proxy_host | length > 0
-    - jenkins_proxy_port | length > 0
+    mode: 0700
 
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers

--- a/templates/proxy-configuration.groovy.j2
+++ b/templates/proxy-configuration.groovy.j2
@@ -1,0 +1,21 @@
+/*
+ * Configure HTTP proxy settings available at http://your-jenkins-instance:port/pluginManager/advanced
+ * proxyUrl is your proxy address, equivalent to http.proxyHost parameter
+ * proxyPort is your proxy port, equivalent to http.proxyPort parameter
+ * userName and password are your proxy credentials
+ * Set the noProxyHost list to bypass the proxy for these URLs
+ */
+
+import jenkins.model.*
+
+def proxyUrl = "{{ jenkins_proxy_host }}"
+def proxyPort = {{ jenkins_proxy_port}}
+def userName = "{{ jenkins_proxy_user }}"
+def password = "{{ jenkins_proxy_pass }}"
+def noProxyHost = "{{ jenkins_proxy_noproxy | join(',') }}"
+def jenkins = Jenkins.getInstance()
+
+jenkins.proxy = new hudson.ProxyConfiguration(proxyUrl, proxyPort, userName, password, noProxyHost)
+jenkins.proxy.save()
+
+return

--- a/templates/proxy.xml
+++ b/templates/proxy.xml
@@ -1,7 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<proxy>
-  <name>{{ jenkins_proxy_host }}</name>
-  <port>{{ jenkins_proxy_port}}</port>
-  <noProxyHost>{{ jenkins_proxy_noproxy | join(',') }}</noProxyHost>
-  <secretPassword></secretPassword>
-</proxy>


### PR DESCRIPTION
Proxy created placing a groovy script in the init folder

New variables jenkins_proxy_user and jenkins_proxy_pass can be specified
optionally

Fixes #317