### PR TITLE
Support HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ The Jenkins home directory which, amongst others, is being used for storing arti
 
 The HTTP port for Jenkins' web interface.
 
+    jenkins_https_port: 8443
+
+The HTTPS port for Jenkins' web interface over SSL. If specifying a port different than -1, then also ensure that a OpenSSL certificate and (vault-encrypted) key are also specified in the follow options.
+
+    jenkins_https_crt: path/to/openssl_certificate.crt
+    jenkins_https_key: path/to/openssl_certificate.key
+
+The OpenSSL signed certificate and (vault-encrypted) key pair for Jenkins to use with HTTPS.
+
     jenkins_admin_username: admin
     jenkins_admin_password: admin
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ jenkins_http_port: 8080
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
+jenkins_args: '--prefix={{ jenkins_url_prefix }}'
 
 # Plugin list can use the plugin name, or a name/version dict.
 jenkins_plugins: []
@@ -39,7 +40,7 @@ jenkins_process_group: "{{ jenkins_process_user }}"
 
 jenkins_init_changes:
   - option: "JENKINS_ARGS"
-    value: "--prefix={{ jenkins_url_prefix }}"
+    value: "{{ jenkins_args }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,10 +14,13 @@ jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
+jenkins_https_port: -1
+jenkins_https_crt: jenkins.crt
+jenkins_https_key: jenkins.key
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_url_prefix: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
-jenkins_args: '--prefix={{ jenkins_url_prefix }}'
+jenkins_args: "--prefix={{ jenkins_url_prefix }} --httpsPort={{ jenkins_https_port }} --httpsCertificate=${{ jenkins_https_crt_param }} --httpsPrivateKey=${{ jenkins_https_key_param }}"
 
 # Plugin list can use the plugin name, or a name/version dict.
 jenkins_plugins: []
@@ -43,6 +46,16 @@ jenkins_init_changes:
     value: "{{ jenkins_args }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
+
+jenkins_https_files:
+  - src: "{{ jenkins_https_crt }}"
+    dst: "{{ jenkins_home }}/secrets/{{ jenkins_https_crt | basename }}"
+    mode: '0444'
+    decrypt: no
+  - src: "{{ jenkins_https_key }}"
+    dst: "{{ jenkins_home }}/secrets/{{ jenkins_https_key | basename }}"
+    mode: '0400'
+    decrypt: yes
 
 # If Jenkins is behind a proxy, configure this.
 jenkins_proxy_host: ""

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -48,6 +48,30 @@
     mode: 0644
   register: jenkins_http_config
 
+- name: Set HTTPS port in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_https_port_param }}='
+    insertafter: "^{{ jenkins_http_port_param }}"
+    line: '{{ jenkins_https_port_param }}={{ jenkins_https_port }}'
+  register: jenkins_https_port_config
+
+- name: Set HTTPS certificate path in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_https_crt_param }}='
+    insertafter: "^{{ jenkins_https_port_param }}"
+    line: '{{ jenkins_https_crt_param }}=$JENKINS_HOME/secrets/{{ jenkins_https_crt | basename }}'
+  register: jenkins_https_crt_config
+
+- name: Set HTTPS private key path in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_https_key_param }}='
+    insertafter: "^{{ jenkins_https_crt_param }}"
+    line: '{{ jenkins_https_key_param }}=$JENKINS_HOME/secrets/{{ jenkins_https_key | basename }}'
+  register: jenkins_https_key_config
+
 - name: Create custom init scripts directory.
   file:
     path: "{{ jenkins_home }}/init.groovy.d"
@@ -68,6 +92,17 @@
     - jenkins_proxy_host | length > 0
     - jenkins_proxy_port | length > 0
 
+- name: Copy HTTPS files to Jenkins controller
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dst }}"
+    mode: "{{ item.mode }}"
+    decrypt: "{{ item.decrypt }}"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+  with_items: "{{ jenkins_https_files }}"
+  when: jenkins_https_port != -1
+
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers
 
@@ -77,6 +112,9 @@
     (jenkins_users_config is defined and jenkins_users_config.changed)
     or (jenkins_init_prefix is defined and jenkins_init_prefix.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)
+    or (jenkins_https_port_config is defined and jenkins_https_port_config.changed)
+    or (jenkins_https_crt_config is defined and jenkins_https_crt_config.changed)
+    or (jenkins_https_key_config is defined and jenkins_https_key_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
     or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)
   tags: ['skip_ansible_lint']

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -39,11 +39,6 @@
     mode: 0644
   register: jenkins_home_config
 
-- name: Immediately restart Jenkins on init config changes.
-  service: name=jenkins state=restarted
-  when: jenkins_init_prefix.changed
-  tags: ['skip_ansible_lint']
-
 - name: Set HTTP port in Jenkins config.
   lineinfile:
     backrefs: true
@@ -80,6 +75,7 @@
   service: name=jenkins state=restarted
   when: >
     (jenkins_users_config is defined and jenkins_users_config.changed)
+    or (jenkins_init_prefix is defined and jenkins_init_prefix.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
     or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,4 +4,7 @@ __jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_pr
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
 jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT
+jenkins_https_port_param: HTTPS_PORT
+jenkins_https_crt_param: HTTPS_CRT
+jenkins_https_key_param: HTTPS_KEY
 jenkins_java_options_env_var: JAVA_ARGS

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,4 +4,7 @@ __jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_pr
 __jenkins_pkg_url: https://pkg.jenkins.io/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT
+jenkins_https_port_param: JENKINS_HTTPS_PORT
+jenkins_https_crt_param: JENKINS_HTTPS_CRT
+jenkins_https_key_param: JENKINS_HTTPS_KEY
 jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS


### PR DESCRIPTION
This contains 3 commits:
 2242afd is a refactor enabling other command ARGS to be passed via the init file
 53ae444 fixes an issue which allows the role to restart Jenkins more accurately
 bfd17a7 introduces HTTPS support

I have tested this on Debian 10, but not CentOS because I don't have a system at hand for testing.
I could not run molecule tests despite trying as I'm unfamiliar with it. Run into docker driver issues.
I therefore did not add molecule tests for HTTPS, but I imagine those wouldn't be hard to add with a self-signed mock certificate.