### PR TITLE
Permissions fix for default.json

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,6 +23,7 @@
     mode: 0755
 
 - name: Download current plugin updates from Jenkins update site.
+  become: True
   get_url:
     url: "{{ jenkins_updates_url }}/update-center.json"
     dest: "{{ jenkins_home }}/updates/default.json"


### PR DESCRIPTION
Up until recently everything has been working, but since upgrading jenkins from v2.176.x to v2.319.x, I've had issues related due to permissions when executing 'ansible-role-jenkins'

The trigger appears to be around `/var/lib/jenkins/updates/default.json' and if you do a 'Check now' within jenkins itself. After 'Check now' is manually done, ansible can't download and update default.json.
