### PR TITLE
Debian apt to ansible package

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure dependencies are installed.
-  apt:
+  package:
     name:
       - curl
       - apt-transport-https
@@ -40,7 +40,7 @@
   notify: configure default users
 
 - name: Ensure Jenkins is installed.
-  apt:
+  package:
     name: jenkins
     state: "{{ jenkins_package_state }}"
   notify: configure default users


### PR DESCRIPTION
Noticed a few apt usages can be simply package tasks. So easier to diff with Redhat version if needed.