### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,6 +22,9 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - all
+    - name: Amazon
+      versions:
+        - 2
   galaxy_tags:
     - development
     - packaging

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,7 +12,7 @@
       - "{{ 'libselinux-python' if ansible_python['version']['major'] < 3 else 'python3-libselinux' }}"
     state: present
   when: (ansible_distribution == 'Amazon' and ansible_python['version']['major'] > 3) or
-        (ansible_distribution == 'Amazon' and ansible_distribution_major_version < 2) or
+        (ansible_distribution == 'Amazon' and ansible_distribution_major_version | int < 2) or
         (ansible_distribution != 'Amazon')
         
 - name: Ensure Jenkins repo is installed.

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -4,9 +4,17 @@
     name:
       - curl
       - initscripts
-      - "{{ 'libselinux-python' if ansible_python['version']['major'] < 3 else 'python3-libselinux' }}"
     state: present
 
+- name: Ensure libselinux for python is installed.
+  package:
+    name:
+      - "{{ 'libselinux-python' if ansible_python['version']['major'] < 3 else 'python3-libselinux' }}"
+    state: present
+  when: (ansible_distribution == 'Amazon' and ansible_python['version']['major'] > 3) or
+        (ansible_distribution == 'Amazon' and ansible_distribution_major_version < 2) or
+        (ansible_distribution != 'Amazon')
+        
 - name: Ensure Jenkins repo is installed.
   get_url:
     url: "{{ jenkins_repo_url }}"


### PR DESCRIPTION
I needed this to work on Amazon Linux 2, but it appears that `python3-libselinux` is not available in the AL2 repos. Interestingly enough, even though AL2 doesn't support SELinux, `libselinux-python` _is_ in the repos...

In light of this, I split out the installation of this specific package and configured it to install only when one of the follow three statements is true:

1. You're running this on Amazon Linux, and you're using python 2.
2. You're running this on future versions of Amazon Linux that have support for SELinux and will most likely have this package in it's repo. (i.e. AL 2022)
3. You're running this on anything other than Amazon Linux.