### PR TITLE
Replace deprecated apt_key usage

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,9 +8,11 @@
     state: present
 
 - name: Add Jenkins apt repository key.
-  apt_key:
+  ansible.builtin.get_url:
     url: "{{ jenkins_repo_key_url }}"
-    state: present
+    dest: /etc/apt/trusted.gpg.d/jenkins.gpg
+    mode: '0644'
+    force: true
 
 - name: Add Jenkins apt repository.
   apt_repository:


### PR DESCRIPTION
When installing with the role on Ubuntu we are seeing:

```
W: https://pkg.jenkins.io/debian/binary/Release.gpg: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```

As far as I could tell, this is the recommended replacement and should be supported for quite some time now.