### PR TITLE
expose jenkins listening address functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The Jenkins home directory which, amongst others, is being used for storing arti
 
 The HTTP port for Jenkins' web interface.
 
+    jenkins_listen_address: 0.0.0.0
+
+The IP address Jenkins listens on for HTTP requests. Default is all interfaces (0.0.0.0).
+
     jenkins_admin_username: admin
     jenkins_admin_password: admin
 

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -53,6 +53,15 @@
     mode: 0644
   register: jenkins_http_config
 
+- name: Set listen address in Jenkins config.
+  lineinfile:
+    backrefs: true
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_listen_address_param }}='
+    line: '{{ jenkins_listen_address_param }}=\"{{ jenkins_listen_address | default("0.0.0.0") }}\"'
+    mode: 0644
+  register: jenkins_http_config
+
 - name: Create custom init scripts directory.
   file:
     path: "{{ jenkins_home }}/init.groovy.d"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,3 +5,4 @@ __jenkins_pkg_url: https://pkg.jenkins.io/redhat
 jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT
 jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS
+jenkins_listen_address_param: JENKINS_LISTEN_ADDRESS


### PR DESCRIPTION
this allows us to limit which interface jenkins listens on.