### PR TITLE
Revert "Replace deprecated apt_key usage"

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,11 +8,9 @@
     state: present
 
 - name: Add Jenkins apt repository key.
-  ansible.builtin.get_url:
+  apt_key:
     url: "{{ jenkins_repo_key_url }}"
-    dest: /etc/apt/trusted.gpg.d/jenkins.gpg
-    mode: '0644'
-    force: true
+    state: present
 
 - name: Add Jenkins apt repository.
   apt_repository:


### PR DESCRIPTION
Reverts geerlingguy/ansible-role-jenkins#355

This seems to not be adequate to add the key, I'm seeing some CI build failures with the modification.

```
Failed to update apt cache: W:https://pkg.jenkins.io/debian/binary/Release.gpg: The key(s) in the keyring /etc/apt/trusted.gpg.d/jenkins.gpg are ignored as the file has an unsupported filetype., W:GPG error: https://pkg.jenkins.io/debian binary/ Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FCEF32E745F2C3D5, E:The repository 'https://pkg.jenkins.io/debian binary/ Release' is not signed., W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., W:http://ports.ubuntu.com/ubuntu-ports/dists/jammy/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg.d/jenkins.gpg are ignored as the file has an unsupported filetype., W:http://ports.ubuntu.com/ubuntu-ports/dists/jammy-updates/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg.d/jenkins.gpg are ignored as the file has an unsupported filetype., W:http://ports.ubuntu.com/ubuntu-ports/dists/jammy-backports/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg.d/jenkins.gpg are ignored as the file has an unsupported filetype., W:http://ports.ubuntu.com/ubuntu-ports/dists/jammy-security/InRelease: The key(s) in the keyring /etc/apt/trusted.gpg.d/jenkins.gpg are ignored as the file has an unsupported filetype.
```