### PR TITLE
Support HTTPS using keystore arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ The Jenkins home directory which, amongst others, is being used for storing arti
 
 The HTTP port for Jenkins' web interface.
 
+    jenkins_https_port: 8443
+
+The HTTPS port for Jenkins' web interface over SSL. If specifying a port different than -1, then also ensure that a OpenSSL certificate and (vault-encrypted) key are also specified in the follow options.
+
+    jenkins_https_crt: path/to/openssl_certificate.crt
+    jenkins_https_key: path/to/openssl_certificate.key
+
+The OpenSSL signed certificate and (vault-encrypted) key pair for Jenkins to use with HTTPS.
+
     jenkins_admin_username: admin
     jenkins_admin_password: admin
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,11 +14,14 @@ jenkins_connection_retries: 60
 jenkins_home: /var/lib/jenkins
 jenkins_hostname: localhost
 jenkins_http_port: 8080
+jenkins_https_port: -1
+jenkins_https_crt: jenkins.crt
+jenkins_https_key: jenkins.key
 jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_url_prefix: ""
 jenkins_options: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
-jenkins_args: '--prefix={{ jenkins_url_prefix }}'
+jenkins_args: "--prefix={{ jenkins_url_prefix }} --httpsPort={{ jenkins_https_port }} --httpsCertificate=${{ jenkins_https_crt_param }} --httpsPrivateKey=${{ jenkins_https_key_param }}"
 
 # Plugin list can use the plugin name, or a name/version dict.
 jenkins_plugins: []
@@ -53,6 +56,16 @@ jenkins_init_changes:
   - option: "JENKINS_PORT"
     value: "{{ jenkins_http_port }}"
 
+
+jenkins_https_files:
+  - src: "{{ jenkins_https_crt }}"
+    dst: "{{ jenkins_home }}/secrets/{{ jenkins_https_crt | basename }}"
+    mode: '0444'
+    decrypt: no
+  - src: "{{ jenkins_https_key }}"
+    dst: "{{ jenkins_home }}/secrets/{{ jenkins_https_key | basename }}"
+    mode: '0400'
+    decrypt: yes
 
 # If Jenkins is behind a proxy, configure this.
 jenkins_proxy_host: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,10 +18,11 @@ jenkins_https_port: -1
 jenkins_https_crt: jenkins.crt
 jenkins_https_key: jenkins.key
 jenkins_jar_location: /opt/jenkins-cli.jar
+jenkins_keystore_pass: ""
 jenkins_url_prefix: ""
 jenkins_options: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
-jenkins_args: "--prefix={{ jenkins_url_prefix }} --httpsPort={{ jenkins_https_port }} --httpsCertificate=${{ jenkins_https_crt_param }} --httpsPrivateKey=${{ jenkins_https_key_param }}"
+jenkins_args: "--prefix={{ jenkins_url_prefix }} --httpsPort={{ jenkins_https_port }}"
 
 # Plugin list can use the plugin name, or a name/version dict.
 jenkins_plugins: []
@@ -45,8 +46,6 @@ jenkins_process_group: "{{ jenkins_process_user }}"
 jenkins_init_changes:
   - option: "JENKINS_OPTS"
     value: "{{ jenkins_options }}"
-  - option: "JENKINS_ARGS"
-    value: "{{ jenkins_args }}"
   - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
   - option: "JENKINS_HOME"
@@ -56,16 +55,24 @@ jenkins_init_changes:
   - option: "JENKINS_PORT"
     value: "{{ jenkins_http_port }}"
 
+# If using https, these get added to the override.conf
+jenkins_init_https_changes:
+  - option: "JENKINS_HTTPS_PORT"
+    value: "{{ jenkins_https_port }}"
+  - option: "JENKINS_HTTPS_KEYSTORE"
+    value: "{{ jenkins_home }}/secrets/jenkins-https-keystore.p7b"
+  - option: "JENKINS_HTTPS_KEYSTORE_PASSWORD"
+    value: "{{ jenkins_keystore_pass }}"
 
 jenkins_https_files:
   - src: "{{ jenkins_https_crt }}"
     dst: "{{ jenkins_home }}/secrets/{{ jenkins_https_crt | basename }}"
     mode: '0444'
-    decrypt: no
+    decrypt: false
   - src: "{{ jenkins_https_key }}"
     dst: "{{ jenkins_home }}/secrets/{{ jenkins_https_key | basename }}"
     mode: '0400'
-    decrypt: yes
+    decrypt: true
 
 # If Jenkins is behind a proxy, configure this.
 jenkins_proxy_host: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ jenkins_jar_location: /opt/jenkins-cli.jar
 jenkins_url_prefix: ""
 jenkins_options: ""
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
+jenkins_args: '--prefix={{ jenkins_url_prefix }}'
 
 # Plugin list can use the plugin name, or a name/version dict.
 jenkins_plugins: []
@@ -41,7 +42,9 @@ jenkins_process_group: "{{ jenkins_process_user }}"
 jenkins_init_changes:
   - option: "JENKINS_OPTS"
     value: "{{ jenkins_options }}"
-  - option: "JAVA_OPTS"
+  - option: "JENKINS_ARGS"
+    value: "{{ jenkins_args }}"
+  - option: "{{ jenkins_java_options_env_var }}"
     value: "{{ jenkins_java_options }}"
   - option: "JENKINS_HOME"
     value: "{{ jenkins_home }}"

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -49,13 +49,22 @@
     mode: u+rwx
     follow: true
 
-- name: Immediately restart Jenkins on init config changes.
-  systemd:
-    name: jenkins
-    state: restarted
-    daemon_reload: true
-  when: jenkins_init_prefix.changed
-  tags: ['skip_ansible_lint']
+- name: Set the Jenkins home directory.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^JENKINS_HOME=.*'
+    line: 'JENKINS_HOME={{ jenkins_home }}'
+    mode: 0644
+  register: jenkins_home_config
+
+- name: Set HTTP port in Jenkins config.
+  lineinfile:
+    backrefs: true
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_http_port_param }}='
+    line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
+    mode: 0644
+  register: jenkins_http_config
 
 - name: Create custom init scripts directory.
   file:
@@ -84,6 +93,7 @@
   service: name=jenkins state=restarted
   when: >
     (jenkins_users_config is defined and jenkins_users_config.changed)
+    or (jenkins_init_prefix is defined and jenkins_init_prefix.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
     or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -66,6 +66,30 @@
     mode: 0644
   register: jenkins_http_config
 
+- name: Set HTTPS port in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_https_port_param }}='
+    insertafter: "^{{ jenkins_http_port_param }}"
+    line: '{{ jenkins_https_port_param }}={{ jenkins_https_port }}'
+  register: jenkins_https_port_config
+
+- name: Set HTTPS certificate path in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_https_crt_param }}='
+    insertafter: "^{{ jenkins_https_port_param }}"
+    line: '{{ jenkins_https_crt_param }}=$JENKINS_HOME/secrets/{{ jenkins_https_crt | basename }}'
+  register: jenkins_https_crt_config
+
+- name: Set HTTPS private key path in Jenkins config.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    regexp: '^{{ jenkins_https_key_param }}='
+    insertafter: "^{{ jenkins_https_crt_param }}"
+    line: '{{ jenkins_https_key_param }}=$JENKINS_HOME/secrets/{{ jenkins_https_key | basename }}'
+  register: jenkins_https_key_config
+
 - name: Create custom init scripts directory.
   file:
     path: "{{ jenkins_home }}/init.groovy.d"
@@ -86,6 +110,17 @@
     - jenkins_proxy_host | length > 0
     - jenkins_proxy_port | length > 0
 
+- name: Copy HTTPS files to Jenkins controller
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dst }}"
+    mode: "{{ item.mode }}"
+    decrypt: "{{ item.decrypt }}"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+  with_items: "{{ jenkins_https_files }}"
+  when: jenkins_https_port != -1
+
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers
 
@@ -95,6 +130,9 @@
     (jenkins_users_config is defined and jenkins_users_config.changed)
     or (jenkins_init_prefix is defined and jenkins_init_prefix.changed)
     or (jenkins_http_config is defined and jenkins_http_config.changed)
+    or (jenkins_https_port_config is defined and jenkins_https_port_config.changed)
+    or (jenkins_https_crt_config is defined and jenkins_https_crt_config.changed)
+    or (jenkins_https_key_config is defined and jenkins_https_key_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
     or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)
   tags: ['skip_ansible_lint']

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -57,38 +57,46 @@
     mode: 0644
   register: jenkins_home_config
 
-- name: Set HTTP port in Jenkins config.
+- name: Copy HTTPS files to Jenkins controller
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dst }}"
+    mode: "{{ item.mode }}"
+    decrypt: "{{ item.decrypt }}"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+  with_items: "{{ jenkins_https_files }}"
+  register: jenkins_https_files_config
+  when: jenkins_https_port != -1
+
+- name: Generate Jenkins HTTPS keystore
+  command:
+    cmd: >
+      openssl pkcs12 -inkey {{ jenkins_home }}/secrets/{{ jenkins_https_key | basename }}
+      -in {{ jenkins_home }}/secrets/{{ jenkins_https_crt | basename }}
+      -export -out {{ jenkins_home }}/secrets/jenkins-https-keystore.p7b
+      -password pass:{{ jenkins_keystore_pass }}
+  when: jenkins_https_port != -1 and jenkins_https_files_config.changed
+
+- name: Chown the keystore to the jenkins user
+  file:
+    path: "{{ jenkins_home }}/secrets/jenkins-https-keystore.p7b"
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
+    mode: 0400
+  when: jenkins_https_port != -1 and jenkins_https_files_config.changed
+
+- name: Modify https variables in init file.
   lineinfile:
-    backrefs: true
     dest: "{{ jenkins_init_file }}"
-    regexp: '^{{ jenkins_http_port_param }}='
-    line: '{{ jenkins_http_port_param }}={{ jenkins_http_port }}'
+    insertafter: '^Environment="{{ item.option }}='
+    regexp: '^Environment="{{ item.option }} '
+    line: 'Environment="{{ item.option }}={{ item.value }}"'
+    state: present
     mode: 0644
-  register: jenkins_http_config
-
-- name: Set HTTPS port in Jenkins config.
-  lineinfile:
-    dest: "{{ jenkins_init_file }}"
-    regexp: '^{{ jenkins_https_port_param }}='
-    insertafter: "^{{ jenkins_http_port_param }}"
-    line: '{{ jenkins_https_port_param }}={{ jenkins_https_port }}'
-  register: jenkins_https_port_config
-
-- name: Set HTTPS certificate path in Jenkins config.
-  lineinfile:
-    dest: "{{ jenkins_init_file }}"
-    regexp: '^{{ jenkins_https_crt_param }}='
-    insertafter: "^{{ jenkins_https_port_param }}"
-    line: '{{ jenkins_https_crt_param }}=$JENKINS_HOME/secrets/{{ jenkins_https_crt | basename }}'
-  register: jenkins_https_crt_config
-
-- name: Set HTTPS private key path in Jenkins config.
-  lineinfile:
-    dest: "{{ jenkins_init_file }}"
-    regexp: '^{{ jenkins_https_key_param }}='
-    insertafter: "^{{ jenkins_https_crt_param }}"
-    line: '{{ jenkins_https_key_param }}=$JENKINS_HOME/secrets/{{ jenkins_https_key | basename }}'
-  register: jenkins_https_key_config
+  with_items: "{{ jenkins_init_https_changes }}"
+  when: jenkins_https_port != -1
+  register: jenkins_init_https_config
 
 - name: Create custom init scripts directory.
   file:
@@ -110,17 +118,6 @@
     - jenkins_proxy_host | length > 0
     - jenkins_proxy_port | length > 0
 
-- name: Copy HTTPS files to Jenkins controller
-  copy:
-    src: "{{ item.src }}"
-    dest: "{{ item.dst }}"
-    mode: "{{ item.mode }}"
-    decrypt: "{{ item.decrypt }}"
-    owner: "{{ jenkins_process_user }}"
-    group: "{{ jenkins_process_group }}"
-  with_items: "{{ jenkins_https_files }}"
-  when: jenkins_https_port != -1
-
 - name: Trigger handlers immediately in case Jenkins was installed
   meta: flush_handlers
 
@@ -128,11 +125,9 @@
   service: name=jenkins state=restarted
   when: >
     (jenkins_users_config is defined and jenkins_users_config.changed)
-    or (jenkins_init_prefix is defined and jenkins_init_prefix.changed)
-    or (jenkins_http_config is defined and jenkins_http_config.changed)
-    or (jenkins_https_port_config is defined and jenkins_https_port_config.changed)
-    or (jenkins_https_crt_config is defined and jenkins_https_crt_config.changed)
-    or (jenkins_https_key_config is defined and jenkins_https_key_config.changed)
+    or (jenkins_init_config is defined and jenkins_init_config.changed)
+    or (jenkins_init_https_config is defined and jenkins_init_https_config.changed)
+    or (jenkins_https_files_config is defined and jenkins_https_files_config.changed)
     or (jenkins_home_config is defined and jenkins_home_config.changed)
     or (jenkins_proxy_config is defined and jenkins_proxy_config.changed)
   tags: ['skip_ansible_lint']

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,9 +2,6 @@
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }} binary/
 __jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io.key
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
-jenkins_init_file: /etc/default/jenkins
 jenkins_http_port_param: HTTP_PORT
 jenkins_https_port_param: HTTPS_PORT
-jenkins_https_crt_param: HTTPS_CRT
-jenkins_https_key_param: HTTPS_KEY
-jenkins_java_options_env_var: JAVA_ARGS
+jenkins_java_options_env_var: JAVA_OPTS

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,9 @@
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }} binary/
 __jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io.key
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
+jenkins_init_file: /etc/default/jenkins
+jenkins_http_port_param: HTTP_PORT
+jenkins_https_port_param: HTTPS_PORT
+jenkins_https_crt_param: HTTPS_CRT
+jenkins_https_key_param: HTTPS_KEY
+jenkins_java_options_env_var: JAVA_ARGS

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,9 +2,6 @@
 __jenkins_repo_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.repo
 __jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io.key
 __jenkins_pkg_url: https://pkg.jenkins.io/redhat
-jenkins_init_file: /etc/sysconfig/jenkins
 jenkins_http_port_param: JENKINS_PORT
 jenkins_https_port_param: JENKINS_HTTPS_PORT
-jenkins_https_crt_param: JENKINS_HTTPS_CRT
-jenkins_https_key_param: JENKINS_HTTPS_KEY
 jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,9 @@
 __jenkins_repo_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.repo
 __jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io.key
 __jenkins_pkg_url: https://pkg.jenkins.io/redhat
+jenkins_init_file: /etc/sysconfig/jenkins
+jenkins_http_port_param: JENKINS_PORT
+jenkins_https_port_param: JENKINS_HTTPS_PORT
+jenkins_https_crt_param: JENKINS_HTTPS_CRT
+jenkins_https_key_param: JENKINS_HTTPS_KEY
+jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS


### PR DESCRIPTION
This builds on an earlier closed PR #326 to support HTTPS, which we
have been using to deploy our Jenkins instance.

As of Jenkins v2.363, the --httpsCertificate command line option
was dropped, so we've adapted the code to use --httpsKeyStore and
--httpsKeyStorePassword instead. Note that --httpsKeyStorePassword
is passed on the command line, and so makes it vulnerable to anyone
with ability to see the jenkins server process tree.
