### PR TITLE
Use proxy for plugins update

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -23,12 +23,17 @@
     mode: 0755
 
 - name: Download current plugin updates from Jenkins update site.
+  environment:
+    http_proxy: "{{ jenkins_proxy_host }}:{{ jenkins_proxy_port }}"
+    https_proxy: "{{ jenkins_proxy_host }}:{{ jenkins_proxy_port }}"
+    no_proxy: "{{ jenkins_proxy_noproxy | join(',') }}"
   get_url:
     url: "{{ jenkins_updates_url }}/update-center.json"
     dest: "{{ jenkins_home }}/updates/default.json"
     owner: jenkins
     group: jenkins
     mode: 0440
+    use_proxy: "{{ 'yes' if jenkins_proxy_host != '' else 'no' }}"
   changed_when: false
   register: get_result
   until: get_result is success


### PR DESCRIPTION
Hello,

Currently it's possible to setup proxy on jenkins using variables like `jenkins_proxy_host`.
Often we set proxy to be able to download jenkins plugins through proxy.
However the task "Download current plugin updates from Jenkins update site." is not using proxy at the moment.
This PR is to use proxy also on this task.

Regards,