### PR TITLE
adding openjdk-8-jdk as default dependency

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -5,6 +5,7 @@
       - curl
       - apt-transport-https
       - gnupg
+      - openjdk-8-jdk
     state: present
 
 - name: Add Jenkins apt repository key.


### PR DESCRIPTION
adding this suggestion to be stupid-proof, took about 3 hours to understand jenkins  does not installs java jdk despite it being the main depency