### PR TITLE
Fix plugin updates metadata URL

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -24,7 +24,7 @@
 
 - name: Download current plugin updates from Jenkins update site.
   get_url:
-    url: "{{ jenkins_updates_url }}/update-center.json"
+    url: "{{ jenkins_updates_url }}/update-center.actual.json"
     dest: "{{ jenkins_home }}/updates/default.json"
     owner: jenkins
     group: jenkins
@@ -34,11 +34,6 @@
   until: get_result is success
   retries: 3
   delay: 2
-
-- name: Remove first and last line from json file.
-  replace:  # noqa 208
-    path: "{{ jenkins_home }}/updates/default.json"
-    regexp: "1d;$d"
 
 - name: Install Jenkins plugins using password.
   jenkins_plugin:


### PR DESCRIPTION
The replace part of plugin installation tasks doesn't seems to work. I see such logs when trying to install plugins with this role. I've tested the replace task alone and it is never remove the lines. 
```
Jan  1 11:08:22 jenkins ansible-get_url: Invoked with url=https://updates.jenkins.io/update-center.json dest=/var/lib/jenkins/updates/default.json owner=jenkins group=jenkins mode=288 force=False http_agent=ansible-httpget use_proxy=True validate_certs=True force_basic_auth=False use_gssapi=False backup=False sha256sum= checksum= timeout=10 unredirected_headers=[] unsafe_writes=False url_username=None url_password=NOT_LOGGING_PARAMETER client_cert=None client_key=None headers=None tmp_dest=None seuser=None serole=None selevel=None setype=None attributes=None
Jan  1 11:08:35 jenkins ansible-replace: Invoked with path=/var/lib/jenkins/updates/default.json regexp=1d;$d replace= backup=False encoding=utf-8 unsafe_writes=False after=None before=None validate=None mode=None owner=None group=None seuser=None serole=None selevel=None setype=None attributes=None
Jan  1 11:08:43 jenkins jenkins[10459]: 2023-01-01 11:08:43.121+0000 [id=13]#011SEVERE#011hudson.model.UpdateSite#getJSONObject: Failed to parse /var/lib/jenkins/updates/default.json
Jan  1 11:08:43 jenkins jenkins[10459]: net.sf.json.JSONException: A JSONObject text must begin with '{' at character 1 of updateCenter.post(

```

Moreover, the same result may be reached by simply requesting file in JSON format from updates server as described in [Jenkins update center documentation](https://github.com/jenkins-infra/update-center2/blob/master/site/LAYOUT.md)