### PR TITLE
Properly set jenkins user and group

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -18,16 +18,16 @@
   file:
     path: "{{ jenkins_home }}/updates"
     state: directory
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0755
 
 - name: Download current plugin updates from Jenkins update site.
   get_url:
     url: "{{ jenkins_updates_url }}/update-center.json"
     dest: "{{ jenkins_home }}/updates/default.json"
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: 0440
   changed_when: false
   register: get_result

--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -40,13 +40,32 @@
   with_items: "{{ jenkins_init_changes }}"
   register: jenkins_init_prefix
 
+- name: Ensure user and group are properly sets on in init file.
+  lineinfile:
+    dest: "{{ jenkins_init_file }}"
+    line: "{{ item }}"
+    state: present
+    mode: 0644
+  with_items:
+    - "User={{ jenkins_process_user }}"
+    - "Group={{ jenkins_process_group }}"
+  register: jenkins_init_prefix
+
 - name: Ensure jenkins_home {{ jenkins_home }} exists.
   file:
     path: "{{ jenkins_home }}"
     state: directory
-    owner: jenkins
-    group: jenkins
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     mode: u+rwx
+    follow: true
+
+- name: Ensure owner and group are properly sets on the cache folder.
+  file:
+    path: /var/cache/jenkins
+    state: directory
+    owner: "{{ jenkins_process_user }}"
+    group: "{{ jenkins_process_group }}"
     follow: true
 
 - name: Immediately restart Jenkins on init config changes.


### PR DESCRIPTION
This should fix the fact that user and group were not properly sets not only the service process itself but also on various directories used by jenkins, this is problematic when something else than default (jenkins) is used.

here is the issue:

https://github.com/geerlingguy/ansible-role-jenkins/issues/373
