### PR TITLE
fix: Use new Debian repository signing keys

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }} binary/
-__jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io.key
+__jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary


### PR DESCRIPTION
This pull request addresses issue [#378](https://github.com/geerlingguy/ansible-role-jenkins/issues/378) . The purpose of this update is to ensure compatibility with Jenkins' new repository signing keys.

Jenkins has recently made changes to its signing keys. As a result, requests that do not utilize these new keys are being blocked. To maintain the functionality and security of the Jenkins role it is necessary to update the signing keys used within the code.

For more information please refer to the following link: [Jenkins Blog - Repository Signing Keys Changing](https://www.jenkins.io/blog/2023/03/27/repository-signing-keys-changing/)

Thank you for considering this pull request.