### PR TITLE
Remove whitespace that makes regexp matches unlikely.

### DIFF
--- a/tasks/settings.yml
+++ b/tasks/settings.yml
@@ -33,7 +33,7 @@
   lineinfile:
     dest: "{{ jenkins_init_file }}"
     insertafter: '^Environment="{{ item.option }}='
-    regexp: '^Environment="{{ item.option }} '
+    regexp: '^Environment="{{ item.option }}='
     line: 'Environment="{{ item.option }}={{ item.value }}"'
     state: present
     mode: 0644

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }} binary/
 __jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
-__jenkins_pkg_url: https://pkg.jenkins.io/debian/binary
+__jenkins_pkg_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/binary


### PR DESCRIPTION
I might misunderstand something but the current regex does not seem to be useful. Applying the role with `jenkins_java_options` to `-Djava.awt.headless=true -Xmx{{ jenkins_java_heapsize_mb }}m` results in the following config file's content:
```
...
Environment="JAVA_OPTS=-Djenkins.install.runSetupWizard=false"
Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx6000m"
...
```
although I would expect having just only one `JAVA_OPTS` string: `Environment="JAVA_OPTS=-Djava.awt.headless=true -Xmx6000m"`.

