### PR TITLE
Fix CI status badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: Jenkins CI
 
-[![CI](https://github.com/geerlingguy/ansible-role-jenkins/workflows/CI/badge.svg?event=push)](https://github.com/geerlingguy/ansible-role-jenkins/actions?query=workflow%3ACI)
+[![CI](https://github.com/geerlingguy/ansible-role-jenkins/actions/workflows/ci.yml/badge.svg)](https://github.com/geerlingguy/ansible-role-jenkins/actions/workflows/ci.yml)
 
 Installs Jenkins CI on RHEL/CentOS and Debian/Ubuntu servers.
 


### PR DESCRIPTION
Current status badge is shown as "failing" although latest CI run has passed. 

Reference: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name.