### PR TITLE
Add `jenkins_restart_method` to allow a `safe restart` to be performed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Changes made to the Jenkins systemd override.conf file; the default set of chang
 
 If you are running Jenkins behind a proxy server, configure these options appropriately. Otherwise Jenkins will be configured with a direct Internet connection.
 
+    jenkins_restart_method: `service`
+
+You can change `jenkins_restart_method` to `safe-restart`, if you want to make sure all running jobs on the Jenkins server are completed. Otherwise `service` will restart the Jenkins systemd-service.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,3 +60,5 @@ jenkins_proxy_noproxy:
 
 jenkins_init_folder: "/etc/systemd/system/jenkins.service.d"
 jenkins_init_file: "{{ jenkins_init_folder }}/override.conf"
+
+jenkins_restart_behavior: "service"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart jenkins
-  service: name=jenkins state=restarted
+  include_tasks: tasks/restart.yml
 
 - name: configure default users
   template:

--- a/tasks/restart.yml
+++ b/tasks/restart.yml
@@ -1,0 +1,8 @@
+---
+- name: restart jenkins via service
+  service: name=jenkins state=restarted
+  when: jenkins_restart_behavior == 'service'
+
+- name: safe-restart jenkins via CLI
+  ansible.builtin.command: java -jar {{ jenkins_jar_location }} -auth {{ jenkins_admin_username }}:{{ jenkins_admin_password }} -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} safe-restart
+  when: jenkins_restart_behavior == 'safe-restart'


### PR DESCRIPTION
Hi @geerlingguy 🙂,

as I described here #390, I want to update my Jenkins server itself. With this variable I can run the Jenkins CLI with `safe-restart` and everything is fine.