### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ Changes made to the Jenkins systemd override.conf file; the default set of chang
 
 If you are running Jenkins behind a proxy server, configure these options appropriately. Otherwise Jenkins will be configured with a direct Internet connection.
 
-    jenkins_restart_method: `service`
+    jenkins_restart_behavior: `service`
 
-You can change `jenkins_restart_method` to `safe-restart`, if you want to make sure all running jobs on the Jenkins server are completed. Otherwise `service` will restart the Jenkins systemd-service.
+You can change `jenkins_restart_behavior` to `safe-restart`, if you want to make sure all running jobs on the Jenkins server are completed. Otherwise `service` will restart the Jenkins systemd-service.
 
 ## Dependencies
 


### PR DESCRIPTION
Replace `jenkins_restart_method` with the correct property name `jenkins_restart_behavior`