### PR TITLE
Fix dependency updates for Jenkins plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Jenkins plugins to be installed automatically during provisioning. Defaults to e
 
 Whether Jenkins plugins to be installed should also install any plugin dependencies.
 
+    jenkins_plugin_update_dependencies: true
+
+Whether the dependencies of Jenkins plugins should be updated. Together with setting `jenkins_plugins_state` to `latest`, this will ensure that all your plugins and dependencies are up to date.
+
     jenkins_plugins_state: present
 
 Use `latest` to ensure all plugins are running the most up-to-date version. For any plugin that has a specific version set in `jenkins_plugins` list, state `present` will be used instead of `jenkins_plugins_state` value.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ jenkins_plugins_state: present
 jenkins_plugin_updates_expiration: 86400
 jenkins_plugin_timeout: 30
 jenkins_plugins_install_dependencies: true
+jenkins_plugin_update_dependencies: false
 jenkins_updates_url: "https://updates.jenkins.io"
 
 jenkins_admin_username: admin

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -61,3 +61,28 @@
   until: plugin_result is success
   retries: 3
   delay: 2
+
+- name: Update Jenkins plugins dependencies
+  when: jenkins_plugin_update_dependencies
+  ansible.builtin.shell: |
+    set -o pipefail
+    # This will ensure that only plugins with a pending update are updated.
+    # The output of `list-plugin` is a list of all plugins, but only those with a closing bracket ")" at the end have a pending update.
+    UPDATE_LIST=$( \
+      java -jar {{ jenkins_jar_location }} \
+      -auth {{ jenkins_admin_username }}:{{ jenkins_admin_password }} \
+      -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} \
+      list-plugins | \
+      grep -e ')$' | \
+      awk '{ print $1 }' \
+    );
+    if [ ! -z "${UPDATE_LIST}" ]; then
+        echo Updating Jenkins Plugins: ${UPDATE_LIST};
+        java -jar {{ jenkins_jar_location }} \
+          -auth {{ jenkins_admin_username }}:{{ jenkins_admin_password }} \
+          -s http://{{ jenkins_hostname }}:{{ jenkins_http_port }} \
+          install-plugin ${UPDATE_LIST};
+    fi
+  register: result
+  changed_when: result.stdout.startswith("Updating Jenkins Plugins:")
+  notify: restart jenkins


### PR DESCRIPTION
I have noticed that dependent plugins are not being updated. Are you having the same problem?

I have not found a way to change this behaviour with the community `jenkins_plugin` you are using.

Basically, this calls the jenkins-CLI `list-plugins` command and filters out each plugin that needs to be updated.

The output will normally look like this:

```text
workflow-cps                       Pipeline: Groovy                            3953.v19f11da_8d2fa_ (3975.v567e2a_1ffa_22)
workflow-durable-task-step         Pipeline: Nodes and Processes               1371.vb_7cec8f3b_95e
workflow-job                       Pipeline: Job                               1436.vfa_244484591f (1459.v6c531091efcd)
workflow-multibranch               Pipeline: Multibranch                       795.ve0cb_1f45ca_9a_
workflow-scm-step                  Pipeline: SCM Step                          427.v4ca_6512e7df1
workflow-step-api                  Pipeline: Step API                          678.v3ee58b_469476
workflow-support                   Pipeline: Supporting APIs                   930.vf51d22b_ce488
```

Therefore every line that ends with a ")" needs an update.

To not change the current behaviour, the default of `jenkins_plugin_update_dependencies` is false.