### PR TITLE
Update Jenkins Signing Keys for 2026

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,4 @@
 ---
 __jenkins_repo_url: deb https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }} binary/
-__jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
+__jenkins_repo_key_url: https://pkg.jenkins.io/debian{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2026.key
 __jenkins_pkg_url: https://pkg.jenkins.io/debian/binary

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
 __jenkins_repo_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.repo
-__jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
+__jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2026.key
 __jenkins_pkg_url: https://pkg.jenkins.io/redhat


### PR DESCRIPTION
The signing keys for standard version have recently expired and will on 21st of January for LTS:

https://www.jenkins.io/blog/2025/12/23/repository-signing-keys-changing/