### PR TITLE
corrections for ansible > 12 and corrected redhat url for fetching LTS packages

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -5,7 +5,7 @@
     src: "{{ jenkins_admin_password_file }}"
   register: adminpasswordfile
   no_log: true
-  when: jenkins_admin_password_file | default(false)
+  when: jenkins_admin_password_file | default("") != ""
   tags: ['skip_ansible_lint']
 
 - name: Set Jenkins admin password fact.
@@ -54,7 +54,7 @@
     url: "http://{{ jenkins_hostname }}:{{ jenkins_http_port }}{{ jenkins_url_prefix }}"
     with_dependencies: "{{ jenkins_plugins_install_dependencies }}"
   with_items: "{{ jenkins_plugins }}"
-  when: jenkins_admin_password | default(false)
+  when: jenkins_admin_password | default("") != ""
   notify: restart jenkins
   tags: ['skip_ansible_lint']
   register: plugin_result

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -12,13 +12,13 @@
   get_url:
     url: "{{ jenkins_repo_url }}"
     dest: /etc/yum.repos.d/jenkins.repo
-  when: jenkins_repo_url | default(false)
+  when: (jenkins_repo_url | default("")) != ""
 
 - name: Add Jenkins repo GPG key.
   rpm_key:
     state: present
     key: "{{ jenkins_repo_key_url }}"
-  when: jenkins_repo_url | default(false)
+  when: (jenkins_repo_url | default("")) != ""
 
 - name: Download specific Jenkins version.
   get_url:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
 __jenkins_repo_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.repo
 __jenkins_repo_key_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}/jenkins.io-2023.key
-__jenkins_pkg_url: https://pkg.jenkins.io/redhat
+__jenkins_pkg_url: https://pkg.jenkins.io/redhat{{ '-stable' if (jenkins_prefer_lts | bool) else '' }}


### PR DESCRIPTION
Role failed on ansible 13.2 due to changes in ansible 12.

The role fetches jenkins package from redhat repo that has only recent packages. var jenkins_prefer_lts didn't work for fetching the jenkins package